### PR TITLE
[codex] Improve Lens dogfood telemetry churn reporting

### DIFF
--- a/Editor/Lens/Bridge.cs
+++ b/Editor/Lens/Bridge.cs
@@ -905,7 +905,7 @@ namespace Becool.UnityMcpLens.Editor
                             // Fire-and-forget: write response when ready (non-blocking).
                             // The reader loop continues immediately so multiple commands
                             // can be in-flight concurrently (multiplexed by requestId).
-                            _ = WriteResponseWhenReadyAsync(tcs.Task, transport, token);
+                            _ = WriteResponseWhenReadyAsync(tcs.Task, transport, token, command);
                         }
                         catch (Exception ex)
                         {
@@ -1571,18 +1571,69 @@ namespace Becool.UnityMcpLens.Editor
         /// Awaits a response task and writes the result to the transport with write serialization.
         /// Used by the listener loop to fire-and-forget response writes.
         /// </summary>
-        async Task WriteResponseWhenReadyAsync(Task<string> responseTask, IConnectionTransport transport, CancellationToken ct)
+        async Task WriteResponseWhenReadyAsync(Task<string> responseTask, IConnectionTransport transport, CancellationToken ct, Command command)
         {
             try
             {
                 string response = await responseTask.ConfigureAwait(false);
                 await WriteWithLockAsync(transport, response, ct);
             }
-            catch (OperationCanceledException) { /* connection closed */ }
+            catch (OperationCanceledException ex)
+            {
+                RecordBridgeAbortedResponse(command, transport, "transport_closed_before_response", ex.Message);
+            }
             catch (Exception ex)
             {
-                BridgeStatusTracker.MarkCommandFailure(NormalizeTransportFailureReason(ex));
+                string errorKind = NormalizeTransportFailureReason(ex);
+                BridgeStatusTracker.MarkCommandFailure(errorKind);
+                RecordBridgeAbortedResponse(command, transport, errorKind, ex.Message);
                 McpLog.LogDelayed($"Failed to write response: {ex.Message}");
+            }
+        }
+
+        void RecordBridgeAbortedResponse(Command command, IConnectionTransport transport, string errorKind, string errorMessage)
+        {
+            try
+            {
+                var requestJson = command == null
+                    ? string.Empty
+                    : JsonConvert.SerializeObject(new
+                    {
+                        type = command.type,
+                        requestId = command.requestId,
+                        @params = command.@params
+                    }, Formatting.None);
+                var requestBytes = PayloadBudgeting.GetUtf8ByteCount(requestJson);
+                var commandType = command?.type ?? "(null)";
+                PayloadStats.RecordCoverage(
+                    "coverage_bridge_command_response",
+                    commandType,
+                    BuildBridgeCoverageMeta(command, transport, "aborted", 0, errorMessage),
+                    PayloadBudgeting.ComputeSha256($"{transport?.ConnectionId}:{command?.requestId}:{errorKind}:{errorMessage}"),
+                    new PayloadStatOptions
+                    {
+                        EventKind = "bridge_coverage",
+                        ConnectionId = transport?.ConnectionId,
+                        RequestId = command?.requestId,
+                        OperationId = command?.requestId,
+                        WorkflowKind = "mcp_bridge",
+                        Success = false,
+                        ErrorKind = string.IsNullOrWhiteSpace(errorKind) ? "transport_closed_before_response" : errorKind,
+                        ErrorMessageShort = errorMessage,
+                        RepresentationKind = "reference",
+                        PayloadClass = "bridge_command_response",
+                        ExtraFields = new
+                        {
+                            commandType,
+                            requestBytes,
+                            responseBytes = 0,
+                            responseStatus = "aborted"
+                        }
+                    });
+            }
+            catch
+            {
+                // Best-effort telemetry only.
             }
         }
 
@@ -2005,21 +2056,25 @@ namespace Becool.UnityMcpLens.Editor
                         }), "error", error ?? "Failed to update tool packs.");
                     }
 
+                    bool unchanged = string.Equals(manifest.kind, "unchanged", StringComparison.OrdinalIgnoreCase);
                     return ReturnResponse(JsonConvert.SerializeObject(new
                     {
                         status = "success",
                         result = manifest
                     }), "success", null, new PayloadStatOptions
                     {
-                        RepresentationKind = includeSchemas ? "full" : "summary",
+                        RepresentationKind = unchanged ? "reference" : includeSchemas ? "full" : "summary",
                         PayloadClass = "tool_manifest",
+                        Unchanged = unchanged,
                         ExtraFields = new
                         {
                             commandType = command.type,
                             manifestKind = manifest.kind,
+                            manifestReason = manifest.reason,
                             bridgeSessionId = manifest.bridgeSessionId,
                             manifestVersion = manifest.manifestVersion,
-                            activeToolPacks = manifest.activeToolPacks
+                            activeToolPacks = manifest.activeToolPacks,
+                            exportedToolCount = manifest.tools?.Length ?? BridgeManifestBroker.GetExportedToolCount(manifest.activeToolPacks)
                         }
                     });
                 }

--- a/Editor/Lens/Lens/BridgeLensSessionRegistry.cs
+++ b/Editor/Lens/Lens/BridgeLensSessionRegistry.cs
@@ -114,7 +114,13 @@ namespace Becool.UnityMcpLens.Editor.Lens
 
         public static bool TrySetActiveToolPacks(string connectionId, IEnumerable<string> requestedPacks, out string[] normalizedPacks, out string error)
         {
+            return TrySetActiveToolPacks(connectionId, requestedPacks, out normalizedPacks, out _, out error);
+        }
+
+        public static bool TrySetActiveToolPacks(string connectionId, IEnumerable<string> requestedPacks, out string[] normalizedPacks, out bool unchanged, out string error)
+        {
             normalizedPacks = Array.Empty<string>();
+            unchanged = false;
             error = null;
 
             if (string.IsNullOrWhiteSpace(connectionId))
@@ -137,7 +143,13 @@ namespace Becool.UnityMcpLens.Editor.Lens
                     s_States[connectionId] = state;
                 }
 
-                state.ActiveToolPacks = normalizedPacks;
+                var currentPacks = state.ActiveToolPacks?.Length > 0
+                    ? state.ActiveToolPacks
+                    : ToolPackCatalog.DefaultActivePacks;
+                unchanged = currentPacks.SequenceEqual(normalizedPacks, StringComparer.OrdinalIgnoreCase);
+                if (!unchanged)
+                    state.ActiveToolPacks = normalizedPacks;
+
                 state.UpdatedUtc = DateTime.UtcNow;
             }
 

--- a/Editor/Lens/Lens/BridgeManifestBroker.cs
+++ b/Editor/Lens/Lens/BridgeManifestBroker.cs
@@ -258,15 +258,30 @@ namespace Becool.UnityMcpLens.Editor.Lens
             out string error)
         {
             error = null;
-            if (!BridgeLensSessionRegistry.TrySetActiveToolPacks(connectionId, requestedPacks, out var normalizedPacks, out error))
+            if (!BridgeLensSessionRegistry.TrySetActiveToolPacks(connectionId, requestedPacks, out var normalizedPacks, out var unchanged, out error))
                 return null;
 
             lock (s_Lock)
             {
                 EnsureCurrentSnapshotLocked();
-                var filteredCurrent = FilterToolsForPacks(s_CurrentTools, normalizedPacks, includeSchemas);
+                var filteredCurrent = FilterToolsForPacks(s_CurrentTools, normalizedPacks, includeSchemas && !unchanged);
                 var currentHashes = ComputeHashes(filteredCurrent);
                 BridgeLensSessionRegistry.UpdateAcknowledgedManifest(connectionId, s_BridgeSessionId, s_ManifestVersion);
+                if (unchanged)
+                {
+                    return new BridgeManifestResult
+                    {
+                        bridgeSessionId = s_BridgeSessionId,
+                        manifestVersion = s_ManifestVersion,
+                        profileCatalogVersion = ToolPackCatalog.ProfileCatalogVersion,
+                        activeToolPacks = normalizedPacks,
+                        kind = "unchanged",
+                        reason = "tool_packs_unchanged",
+                        hashMinimal = currentHashes.minimal,
+                        hashFull = currentHashes.full
+                    };
+                }
+
                 return CreateFullResult(filteredCurrent, normalizedPacks, currentHashes, "tool_packs_updated");
             }
         }

--- a/Editor/Lens/Lens/Usage/PayloadStatsWindow.cs
+++ b/Editor/Lens/Lens/Usage/PayloadStatsWindow.cs
@@ -76,6 +76,8 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             EditorGUILayout.Space(8f);
             DrawBridgeCommandsSection();
             EditorGUILayout.Space(8f);
+            DrawSessionChurnSection();
+            EditorGUILayout.Space(8f);
             DrawChurnSection();
             EditorGUILayout.Space(8f);
             DrawTopRows("Top Payload Stages", m_Report.TopStages);
@@ -194,6 +196,9 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                 EditorGUILayout.LabelField("Estimated Saved Tokens", $"{FormatNumber(m_Report.SavedTokens)} ({m_Report.SavingsPct:F2}%)");
                 EditorGUILayout.LabelField("Raw Bytes", FormatBytes(m_Report.RawBytes));
                 EditorGUILayout.LabelField("Shaped Bytes", FormatBytes(m_Report.ShapedBytes));
+                EditorGUILayout.LabelField("Shaping Scope", m_Report.ShapingApplicability?.Summary ?? "Payload rows are shaping eligible; coverage rows are shaping n/a.");
+                EditorGUILayout.LabelField("Eligible Payload Rows", FormatNumber(m_Report.ShapingApplicability?.PayloadRowsEligible ?? m_Report.PayloadEntryCount));
+                EditorGUILayout.LabelField("Coverage Rows Shaping", $"n/a ({FormatNumber(m_Report.ShapingApplicability?.CoverageRowsNotApplicable ?? m_Report.CoverageEntryCount)} rows)");
                 EditorGUILayout.LabelField("Exact Duplicate Raw Estimate", $"{FormatBytes(m_Report.ExactRepeatedRawBytes)} ({m_Report.ExactRepeatedRawPct:F2}%)");
                 EditorGUILayout.LabelField("Normalized Duplicate Raw Estimate", $"{FormatBytes(m_Report.NormalizedRepeatedRawBytes)} ({m_Report.NormalizedRepeatedRawPct:F2}%)");
             }
@@ -206,6 +211,8 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             {
                 EditorGUILayout.LabelField("Bridge Requests", FormatNumber(m_Report.BridgeRequestCount));
                 EditorGUILayout.LabelField("Bridge Responses", FormatNumber(m_Report.BridgeResponseCount));
+                EditorGUILayout.LabelField("Bridge Connections", FormatNumber(m_Report.BridgeConnectionCount));
+                EditorGUILayout.LabelField("Unmatched Requests", FormatNumber(m_Report.UnmatchedRequests?.Count ?? 0));
                 EditorGUILayout.LabelField("Bridge Request Bytes", FormatBytes(m_Report.BridgeRequestBytes));
                 EditorGUILayout.LabelField("Bridge Response Bytes", FormatBytes(m_Report.BridgeResponseBytes));
             }
@@ -227,6 +234,54 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                     EditorGUILayout.LabelField(
                         command.Label,
                         $"count {command.Count}, request bytes {FormatBytes(command.RequestBytes)}");
+                }
+            }
+        }
+
+        void DrawSessionChurnSection()
+        {
+            DrawSectionHeader("Session Churn");
+            using (new EditorGUILayout.VerticalScope(EditorStyles.helpBox))
+            {
+                EditorGUILayout.LabelField("Connections", FormatNumber(m_Report.BridgeConnectionCount));
+                EditorGUILayout.LabelField("Setup Cycles", FormatNumber(m_Report.SetupCycleCount));
+                EditorGUILayout.LabelField("Pack-Set Transitions", FormatNumber(m_Report.PackSetTransitions?.Count ?? 0));
+                EditorGUILayout.LabelField("Unmatched Requests", FormatNumber(m_Report.UnmatchedRequests?.Count ?? 0));
+
+                if (m_Report.ConnectionSummaries != null && m_Report.ConnectionSummaries.Count > 0)
+                {
+                    EditorGUILayout.Space(4f);
+                    EditorGUILayout.LabelField("Connections", EditorStyles.boldLabel);
+                    foreach (var connection in m_Report.ConnectionSummaries.Take(k_TopCount))
+                    {
+                        EditorGUILayout.LabelField(
+                            connection.ConnectionId,
+                            $"requests {connection.RequestCount}, responses {connection.ResponseCount}, unmatched {connection.UnmatchedRequestCount}, top {connection.TopCommand}");
+                    }
+                }
+
+                if (m_Report.PackSetTransitions != null && m_Report.PackSetTransitions.Count > 0)
+                {
+                    EditorGUILayout.Space(4f);
+                    EditorGUILayout.LabelField("Pack Sets", EditorStyles.boldLabel);
+                    foreach (var transition in m_Report.PackSetTransitions.Take(k_TopCount))
+                    {
+                        EditorGUILayout.LabelField(
+                            transition.ConnectionId,
+                            $"{transition.ActiveToolPacks} -> {transition.ManifestKind}, unchanged {transition.Unchanged}, response {FormatBytes(transition.ResponseBytes)}");
+                    }
+                }
+
+                if (m_Report.UnmatchedRequests != null && m_Report.UnmatchedRequests.Count > 0)
+                {
+                    EditorGUILayout.Space(4f);
+                    EditorGUILayout.LabelField("Unmatched", EditorStyles.boldLabel);
+                    foreach (var request in m_Report.UnmatchedRequests.Take(k_TopCount))
+                    {
+                        EditorGUILayout.LabelField(
+                            request.CommandType,
+                            $"{request.ConnectionId}, {ShortId(request.RequestId)}, {request.Classification}");
+                    }
                 }
             }
         }
@@ -355,14 +410,24 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                         Hash = ReadString(entry["hash"]),
                         NormalizedHash = ReadString(entry["normalizedHash"]),
                         RunId = ReadString(entry["runId"]),
+                        ConnectionId = ReadString(entry["connectionId"], ReadString(entry.SelectToken("meta.connectionId"))),
+                        RequestId = ReadString(entry["requestId"], ReadString(entry.SelectToken("meta.requestId"))),
                         Success = ReadBool(entry["success"]),
+                        Unchanged = ReadBool(entry["unchanged"]),
                         ErrorKind = ReadString(entry["errorKind"]),
                         CommandType = ReadString(entry["commandType"], ReadString(entry["name"])),
                         RequestBytes = ReadLong(entry["requestBytes"], ReadLong(entry.SelectToken("meta.payloadBytes"))),
                         ResponseBytes = ReadLong(entry["responseBytes"]),
                         DiscoveryMode = ReadString(entry["discoveryMode"], ReadString(entry["toolDiscoveryMode"])),
+                        SnapshotReason = ReadString(entry["snapshotReason"], ReadString(entry["toolDiscoveryReason"])),
                         SnapshotHashMinimal = ReadString(entry["snapshotHashMinimal"]),
-                        SnapshotHashFull = ReadString(entry["snapshotHashFull"])
+                        SnapshotHashFull = ReadString(entry["snapshotHashFull"]),
+                        BridgeSessionId = ReadString(entry["bridgeSessionId"], ReadString(entry.SelectToken("meta.bridgeSessionId"))),
+                        ManifestVersion = ReadLong(entry["manifestVersion"], ReadLong(entry.SelectToken("meta.manifestVersion"))),
+                        ManifestKind = ReadString(entry["manifestKind"], ReadString(entry.SelectToken("meta.manifestKind"))),
+                        ManifestReason = ReadString(entry["manifestReason"], ReadString(entry.SelectToken("meta.manifestReason"))),
+                        ActiveToolPacks = ReadPackList(entry["activeToolPacks"] ?? entry.SelectToken("meta.activeToolPacks")),
+                        ResponseStatus = ReadString(entry["responseStatus"], ReadString(entry.SelectToken("meta.status")))
                     });
                 }
                 catch
@@ -407,6 +472,67 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                 .ThenByDescending(row => row.RequestBytes)
                 .Take(k_TopCount)
                 .ToList();
+
+            var responseKeys = new HashSet<string>(
+                bridgeResponseRows
+                    .Select(BuildBridgeRowKey)
+                    .Where(key => !string.IsNullOrWhiteSpace(key)),
+                StringComparer.Ordinal);
+            var unmatchedRequests = bridgeRequestRows
+                .Where(row => !string.IsNullOrWhiteSpace(BuildBridgeRowKey(row)) && !responseKeys.Contains(BuildBridgeRowKey(row)))
+                .OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue)
+                .Select(row => new UnmatchedRequestRow
+                {
+                    TimestampUtc = row.TimestampUtc,
+                    ConnectionId = row.ConnectionId,
+                    RequestId = row.RequestId,
+                    CommandType = row.CommandType,
+                    RequestBytes = row.RequestBytes,
+                    Classification = ClassifyUnmatchedBridgeRequest(row, orderedRows)
+                })
+                .ToList();
+            var connectionSummaries = rows
+                .Where(row => !string.IsNullOrWhiteSpace(row.ConnectionId))
+                .GroupBy(row => row.ConnectionId)
+                .Select(group =>
+                {
+                    var connectionRows = group.OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue).ToList();
+                    var requests = connectionRows.Where(row => string.Equals(row.Stage, "coverage_bridge_command_request", StringComparison.Ordinal)).ToList();
+                    var responses = connectionRows.Where(row => string.Equals(row.Stage, "coverage_bridge_command_response", StringComparison.Ordinal)).ToList();
+                    var topCommand = requests
+                        .GroupBy(row => string.IsNullOrWhiteSpace(row.CommandType) ? "(unknown)" : row.CommandType)
+                        .OrderByDescending(commandGroup => commandGroup.Count())
+                        .Select(commandGroup => commandGroup.Key)
+                        .FirstOrDefault() ?? "(none)";
+                    return new ConnectionSummaryRow
+                    {
+                        ConnectionId = group.Key,
+                        FirstUtc = connectionRows.FirstOrDefault()?.TimestampUtc,
+                        LastUtc = connectionRows.LastOrDefault()?.TimestampUtc,
+                        RequestCount = requests.Count,
+                        ResponseCount = responses.Count,
+                        UnmatchedRequestCount = unmatchedRequests.Count(request => string.Equals(request.ConnectionId, group.Key, StringComparison.Ordinal)),
+                        TopCommand = topCommand
+                    };
+                })
+                .OrderBy(row => row.FirstUtc ?? DateTimeOffset.MinValue)
+                .ToList();
+            var setupCycleCount = CountSetupCycles(bridgeRequestRows);
+            var packSetTransitions = bridgeResponseRows
+                .Where(row => string.Equals(row.CommandType, "set_tool_packs", StringComparison.Ordinal))
+                .OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue)
+                .Select(row => new PackSetTransitionRow
+                {
+                    TimestampUtc = row.TimestampUtc,
+                    ConnectionId = row.ConnectionId,
+                    RequestId = row.RequestId,
+                    ActiveToolPacks = row.ActiveToolPacks,
+                    ManifestKind = row.ManifestKind,
+                    ManifestReason = row.ManifestReason,
+                    Unchanged = row.Unchanged == true,
+                    ResponseBytes = row.ResponseBytes
+                })
+                .ToList();
             var toolSnapshotRows = rows.Where(row =>
                 string.Equals(row.EventKind, "tool_snapshot", StringComparison.Ordinal) ||
                 string.Equals(row.Stage, "tool_snapshot", StringComparison.Ordinal)).OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue).ToList();
@@ -442,6 +568,7 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                 ShapedBytes = payloadRows.Sum(row => row.ShapedBytes),
                 RawTokens = payloadRows.Sum(row => EstimateTokensFromBytes(row.RawBytes)),
                 ShapedTokens = payloadRows.Sum(row => EstimateTokensFromBytes(row.ShapedBytes)),
+                ShapingApplicability = CreateShapingApplicability(payloadRows.Count, coverageRows.Count, payloadRows.Sum(row => row.RawBytes), payloadRows.Sum(row => row.ShapedBytes), payloadRows.Count(row => row.RawBytes > row.ShapedBytes)),
                 ExactRepeatedRawBytes = exactRepeatedRawBytes,
                 ExactRepeatedRawPct = Percent(exactRepeatedRawBytes, payloadRows.Sum(row => row.RawBytes)),
                 NormalizedRepeatedRawBytes = normalizedRepeatedRawBytes,
@@ -451,6 +578,11 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                 BridgeRequestBytes = bridgeRequestRows.Sum(row => row.RequestBytes),
                 BridgeResponseBytes = bridgeResponseRows.Sum(row => row.ResponseBytes),
                 BridgeTopCommands = bridgeTopCommands,
+                BridgeConnectionCount = connectionSummaries.Count,
+                ConnectionSummaries = connectionSummaries,
+                SetupCycleCount = setupCycleCount,
+                PackSetTransitions = packSetTransitions,
+                UnmatchedRequests = unmatchedRequests,
                 ToolSnapshotCount = toolSnapshotRows.Count,
                 MinimalHashTransitions = minimalTransitions,
                 FullHashTransitions = fullTransitions,
@@ -508,6 +640,103 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
 
             return string.Equals(row.EventKind, "coverage", StringComparison.Ordinal) ||
                 string.Equals(row.EventKind, "bridge_coverage", StringComparison.Ordinal);
+        }
+
+        static ShapingApplicabilityRow CreateShapingApplicability(int payloadRowsEligible, int coverageRowsNotApplicable, long rawBytes, long shapedBytes, int payloadRowsWithSavings)
+        {
+            string summary;
+            if (payloadRowsEligible == 0)
+                summary = "No payload rows recorded; coverage rows are shaping n/a.";
+            else if (rawBytes > 0 && rawBytes == shapedBytes)
+                summary = "No shaping recorded for eligible payload rows; coverage rows are shaping n/a.";
+            else
+                summary = "Payload rows are shaping eligible; coverage rows are shaping n/a.";
+
+            return new ShapingApplicabilityRow
+            {
+                PayloadRowsEligible = payloadRowsEligible,
+                CoverageRowsNotApplicable = coverageRowsNotApplicable,
+                PayloadRowsWithSavings = payloadRowsWithSavings,
+                NoShapingRecorded = rawBytes > 0 && rawBytes == shapedBytes,
+                Summary = summary
+            };
+        }
+
+        static string BuildBridgeRowKey(PayloadRow row)
+        {
+            if (row == null || string.IsNullOrWhiteSpace(row.RequestId))
+                return string.Empty;
+
+            return $"{row.ConnectionId}|{row.RequestId}";
+        }
+
+        static string ClassifyUnmatchedBridgeRequest(PayloadRow request, IReadOnlyList<PayloadRow> orderedRows)
+        {
+            if (request?.TimestampUtc == null || orderedRows == null)
+                return "unmatched_request";
+
+            var requestTime = request.TimestampUtc.Value;
+            var nearbyRows = orderedRows
+                .Where(row => row.TimestampUtc.HasValue &&
+                    row.TimestampUtc.Value > requestTime &&
+                    (row.TimestampUtc.Value - requestTime).TotalSeconds <= 45d)
+                .ToList();
+            bool hasNewConnection = nearbyRows.Any(row =>
+                string.Equals(row.Stage, "coverage_bridge_command_request", StringComparison.Ordinal) &&
+                string.Equals(row.CommandType, "register_client", StringComparison.Ordinal) &&
+                !string.Equals(row.ConnectionId, request.ConnectionId, StringComparison.Ordinal));
+            bool hasSnapshotRefresh = nearbyRows.Any(row =>
+                string.Equals(row.EventKind, "tool_snapshot", StringComparison.Ordinal) ||
+                string.Equals(row.Stage, "tool_snapshot", StringComparison.Ordinal));
+            bool hasReloadHint = nearbyRows.Any(row =>
+                !string.IsNullOrWhiteSpace(row.SnapshotReason) &&
+                (row.SnapshotReason.IndexOf("reload", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    row.SnapshotReason.IndexOf("compile", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    row.SnapshotReason.IndexOf("domain", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                    row.SnapshotReason.IndexOf("bridge_started", StringComparison.OrdinalIgnoreCase) >= 0));
+
+            if (hasNewConnection && (hasSnapshotRefresh || hasReloadHint))
+                return "domain_reload_transport_close";
+
+            if (hasNewConnection)
+                return "transport_reconnect_after_request";
+
+            if (hasSnapshotRefresh)
+                return "snapshot_refresh_after_request";
+
+            return "unmatched_request";
+        }
+
+        static int CountSetupCycles(IReadOnlyList<PayloadRow> bridgeRequestRows)
+        {
+            var count = 0;
+            foreach (var connectionGroup in bridgeRequestRows
+                .OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue)
+                .GroupBy(row => row.ConnectionId))
+            {
+                var requests = connectionGroup.OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue).ToList();
+                foreach (var registerRow in requests.Where(row => string.Equals(row.CommandType, "register_client", StringComparison.Ordinal)))
+                {
+                    if (!registerRow.TimestampUtc.HasValue)
+                        continue;
+
+                    var manifestRow = requests.FirstOrDefault(row =>
+                        row.TimestampUtc.HasValue &&
+                        row.TimestampUtc.Value > registerRow.TimestampUtc.Value &&
+                        string.Equals(row.CommandType, "get_manifest", StringComparison.Ordinal));
+                    if (manifestRow?.TimestampUtc == null)
+                        continue;
+
+                    var schemaRow = requests.FirstOrDefault(row =>
+                        row.TimestampUtc.HasValue &&
+                        row.TimestampUtc.Value > manifestRow.TimestampUtc.Value &&
+                        string.Equals(row.CommandType, "get_tool_schema", StringComparison.Ordinal));
+                    if (schemaRow != null)
+                        count++;
+                }
+            }
+
+            return count;
         }
 
         static string GetStatsPath()
@@ -571,6 +800,22 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
                 : null;
         }
 
+        static string ReadPackList(JToken token)
+        {
+            if (token == null || token.Type == JTokenType.Null)
+                return string.Empty;
+
+            if (token.Type == JTokenType.Array)
+            {
+                return string.Join(",",
+                    token.Values<string>()
+                        .Where(value => !string.IsNullOrWhiteSpace(value))
+                        .Select(value => value.Trim()));
+            }
+
+            return ReadString(token);
+        }
+
         static long EstimateTokensFromBytes(long bytes)
         {
             if (bytes <= 0)
@@ -606,6 +851,14 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             return value.ToString("N0", CultureInfo.InvariantCulture);
         }
 
+        static string ShortId(string value)
+        {
+            if (string.IsNullOrWhiteSpace(value) || value.Length <= 10)
+                return value ?? string.Empty;
+
+            return value.Substring(0, 10);
+        }
+
         static string BuildClipboardReport(PayloadStatsReport report)
         {
             var builder = new StringBuilder();
@@ -622,11 +875,16 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
 
             builder.AppendLine();
             builder.AppendLine($"Payload stats: {FormatNumber(report.RawTokens)} raw tokens -> {FormatNumber(report.ShapedTokens)} shaped tokens, saved {FormatNumber(report.SavedTokens)} tokens ({report.SavingsPct:F2}% savings).");
+            builder.AppendLine($"Shaping applicability: {report.ShapingApplicability?.Summary ?? "Payload rows are shaping eligible; coverage rows are shaping n/a."}");
             builder.AppendLine($"Repeated context estimate: exact {report.ExactRepeatedRawPct:F2}% raw, normalized {report.NormalizedRepeatedRawPct:F2}% raw.");
             builder.AppendLine($"Bridge requests seen: {FormatNumber(report.BridgeRequestCount)}. Bridge responses seen: {FormatNumber(report.BridgeResponseCount)}.");
+            builder.AppendLine($"Session churn: {FormatNumber(report.BridgeConnectionCount)} connections, {FormatNumber(report.SetupCycleCount)} setup cycles, {FormatNumber(report.PackSetTransitions?.Count ?? 0)} pack-set transitions, {FormatNumber(report.UnmatchedRequests?.Count ?? 0)} unmatched requests.");
             builder.AppendLine($"Tool snapshot churn: {FormatNumber(report.ToolSnapshotCount)} rows, {FormatNumber(report.MinimalHashTransitions)} minimal transitions, {FormatNumber(report.FullHashTransitions)} full transitions, {FormatNumber(report.FalseStableMinimalTransitions)} false-stable minimal transitions.");
 
             AppendBridgeCommands(builder, report.BridgeTopCommands);
+            AppendConnectionSummaries(builder, report.ConnectionSummaries);
+            AppendPackSetTransitions(builder, report.PackSetTransitions);
+            AppendUnmatchedRequests(builder, report.UnmatchedRequests);
             AppendSummaryRows(builder, "Top payload stages", report.TopStages);
             AppendSummaryRows(builder, "Top payload names", report.TopNames);
             AppendRunSummaries(builder, report.RunSummaries);
@@ -657,6 +915,45 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             foreach (var row in rows)
             {
                 builder.AppendLine($"- {row.Label}: rows {row.Count}, raw {FormatBytes(row.RawBytes)}, failures {row.FailureCount}");
+            }
+        }
+
+        static void AppendConnectionSummaries(StringBuilder builder, IReadOnlyList<ConnectionSummaryRow> rows)
+        {
+            if (rows == null || rows.Count == 0)
+                return;
+
+            builder.AppendLine();
+            builder.AppendLine("Bridge connections:");
+            foreach (var row in rows.Take(k_TopCount))
+            {
+                builder.AppendLine($"- {row.ConnectionId}: requests {row.RequestCount}, responses {row.ResponseCount}, unmatched {row.UnmatchedRequestCount}, top {row.TopCommand}");
+            }
+        }
+
+        static void AppendPackSetTransitions(StringBuilder builder, IReadOnlyList<PackSetTransitionRow> rows)
+        {
+            if (rows == null || rows.Count == 0)
+                return;
+
+            builder.AppendLine();
+            builder.AppendLine("Pack-set transitions:");
+            foreach (var row in rows.Take(k_TopCount))
+            {
+                builder.AppendLine($"- {row.ConnectionId}: {row.ActiveToolPacks} -> {row.ManifestKind}, unchanged {row.Unchanged}, response {FormatBytes(row.ResponseBytes)}");
+            }
+        }
+
+        static void AppendUnmatchedRequests(StringBuilder builder, IReadOnlyList<UnmatchedRequestRow> rows)
+        {
+            if (rows == null || rows.Count == 0)
+                return;
+
+            builder.AppendLine();
+            builder.AppendLine("Unmatched bridge requests:");
+            foreach (var row in rows.Take(k_TopCount))
+            {
+                builder.AppendLine($"- {row.CommandType}: {row.ConnectionId}, {ShortId(row.RequestId)}, {row.Classification}");
             }
         }
 
@@ -694,6 +991,7 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             public long ShapedTokens { get; set; }
             public long SavedTokens => Math.Max(0L, RawTokens - ShapedTokens);
             public double SavingsPct => Percent(Math.Max(0L, RawBytes - ShapedBytes), RawBytes);
+            public ShapingApplicabilityRow ShapingApplicability { get; set; }
             public long ExactRepeatedRawBytes { get; set; }
             public double ExactRepeatedRawPct { get; set; }
             public long NormalizedRepeatedRawBytes { get; set; }
@@ -703,6 +1001,11 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             public long BridgeRequestBytes { get; set; }
             public long BridgeResponseBytes { get; set; }
             public List<BridgeCommandRow> BridgeTopCommands { get; set; }
+            public int BridgeConnectionCount { get; set; }
+            public List<ConnectionSummaryRow> ConnectionSummaries { get; set; }
+            public int SetupCycleCount { get; set; }
+            public List<PackSetTransitionRow> PackSetTransitions { get; set; }
+            public List<UnmatchedRequestRow> UnmatchedRequests { get; set; }
             public int ToolSnapshotCount { get; set; }
             public int MinimalHashTransitions { get; set; }
             public int FullHashTransitions { get; set; }
@@ -710,6 +1013,15 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             public List<PayloadSummaryRow> TopStages { get; set; }
             public List<PayloadSummaryRow> TopNames { get; set; }
             public List<RunSummaryRow> RunSummaries { get; set; }
+        }
+
+        sealed class ShapingApplicabilityRow
+        {
+            public int PayloadRowsEligible { get; set; }
+            public int CoverageRowsNotApplicable { get; set; }
+            public int PayloadRowsWithSavings { get; set; }
+            public bool NoShapingRecorded { get; set; }
+            public string Summary { get; set; }
         }
 
         sealed class PayloadSummaryRow
@@ -737,6 +1049,39 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             public long RequestBytes { get; set; }
         }
 
+        sealed class ConnectionSummaryRow
+        {
+            public string ConnectionId { get; set; }
+            public DateTimeOffset? FirstUtc { get; set; }
+            public DateTimeOffset? LastUtc { get; set; }
+            public int RequestCount { get; set; }
+            public int ResponseCount { get; set; }
+            public int UnmatchedRequestCount { get; set; }
+            public string TopCommand { get; set; }
+        }
+
+        sealed class PackSetTransitionRow
+        {
+            public DateTimeOffset? TimestampUtc { get; set; }
+            public string ConnectionId { get; set; }
+            public string RequestId { get; set; }
+            public string ActiveToolPacks { get; set; }
+            public string ManifestKind { get; set; }
+            public string ManifestReason { get; set; }
+            public bool Unchanged { get; set; }
+            public long ResponseBytes { get; set; }
+        }
+
+        sealed class UnmatchedRequestRow
+        {
+            public DateTimeOffset? TimestampUtc { get; set; }
+            public string ConnectionId { get; set; }
+            public string RequestId { get; set; }
+            public string CommandType { get; set; }
+            public long RequestBytes { get; set; }
+            public string Classification { get; set; }
+        }
+
         sealed class PayloadRow
         {
             public DateTimeOffset? TimestampUtc { get; set; }
@@ -748,14 +1093,24 @@ namespace Becool.UnityMcpLens.Editor.Lens.Usage
             public string Hash { get; set; }
             public string NormalizedHash { get; set; }
             public string RunId { get; set; }
+            public string ConnectionId { get; set; }
+            public string RequestId { get; set; }
             public bool? Success { get; set; }
+            public bool? Unchanged { get; set; }
             public string ErrorKind { get; set; }
             public string CommandType { get; set; }
             public long RequestBytes { get; set; }
             public long ResponseBytes { get; set; }
             public string DiscoveryMode { get; set; }
+            public string SnapshotReason { get; set; }
             public string SnapshotHashMinimal { get; set; }
             public string SnapshotHashFull { get; set; }
+            public string BridgeSessionId { get; set; }
+            public long ManifestVersion { get; set; }
+            public string ManifestKind { get; set; }
+            public string ManifestReason { get; set; }
+            public string ActiveToolPacks { get; set; }
+            public string ResponseStatus { get; set; }
         }
     }
 }

--- a/Editor/Lens/Tools/ToolPackTools.cs
+++ b/Editor/Lens/Tools/ToolPackTools.cs
@@ -176,21 +176,21 @@ namespace Becool.UnityMcpLens.Editor.Tools
             if (string.IsNullOrWhiteSpace(connectionId))
                 return Task.FromResult<object>(Response.Error("Unity.SetToolPacks requires an active Lens MCP bridge connection."));
 
-            if (!BridgeLensSessionRegistry.TrySetActiveToolPacks(connectionId, parameters?.Packs, out var normalizedPacks, out var error))
-                return Task.FromResult<object>(Response.Error(error ?? "Failed to update active tool packs."));
-
-            var manifest = BridgeManifestBroker.SetToolPacks(connectionId, normalizedPacks, includeSchemas: false, out error);
+            var manifest = BridgeManifestBroker.SetToolPacks(connectionId, parameters?.Packs, includeSchemas: false, out var error);
             if (!string.IsNullOrWhiteSpace(error) || manifest == null)
                 return Task.FromResult<object>(Response.Error(error ?? "Failed to rebuild tool manifest after updating tool packs."));
 
+            bool unchanged = string.Equals(manifest.kind, "unchanged", StringComparison.OrdinalIgnoreCase);
             return Task.FromResult<object>(Response.Success(
-                "Updated active Unity MCP tool packs.",
+                unchanged ? "Active Unity MCP tool packs unchanged." : "Updated active Unity MCP tool packs.",
                 new
                 {
                     activeToolPacks = manifest.activeToolPacks,
                     manifestVersion = manifest.manifestVersion,
                     bridgeSessionId = manifest.bridgeSessionId,
-                    toolCount = manifest.tools?.Length ?? 0,
+                    unchanged,
+                    manifestKind = manifest.kind,
+                    toolCount = manifest.tools?.Length ?? BridgeManifestBroker.GetExportedToolCount(manifest.activeToolPacks),
                     recommendedNextPacks = ToolPackCatalog.GetRecommendedNextPacks(manifest.activeToolPacks)
                 }));
         }

--- a/Tools~/Analyze-PayloadStats.ps1
+++ b/Tools~/Analyze-PayloadStats.ps1
@@ -99,6 +99,78 @@ function Get-BoolValue {
     return $null
 }
 
+function Get-PackListString {
+    param($Value)
+
+    if ($null -eq $Value) {
+        return ""
+    }
+
+    $items = if ($Value -is [System.Array]) {
+        @($Value)
+    } elseif ($Value -is [System.Collections.IEnumerable] -and -not ($Value -is [string])) {
+        @($Value)
+    } else {
+        @($Value)
+    }
+
+    return (@($items |
+        Where-Object { $null -ne $_ -and -not [string]::IsNullOrWhiteSpace([string]$_) } |
+        ForEach-Object { ([string]$_).Trim() }) -join ",")
+}
+
+function Get-BridgeRowKey {
+    param($Row)
+
+    if ($null -eq $Row -or [string]::IsNullOrWhiteSpace($Row.RequestId)) {
+        return $null
+    }
+
+    return "{0}|{1}" -f $Row.ConnectionId, $Row.RequestId
+}
+
+function Get-UnmatchedBridgeRequestClass {
+    param(
+        $RequestRow,
+        $AllRows
+    )
+
+    if ($null -eq $RequestRow -or $null -eq $RequestRow.TimestampUtc) {
+        return "unmatched_request"
+    }
+
+    $nearbyRows = @($AllRows | Where-Object {
+        $_.TimestampUtc -ne $null -and
+        $_.TimestampUtc -gt $RequestRow.TimestampUtc -and
+        ($_.TimestampUtc - $RequestRow.TimestampUtc).TotalSeconds -le 45
+    })
+    $hasNewConnection = @($nearbyRows | Where-Object {
+        $_.Stage -eq "coverage_bridge_command_request" -and
+        $_.CommandType -eq "register_client" -and
+        $_.ConnectionId -ne $RequestRow.ConnectionId
+    }).Count -gt 0
+    $hasSnapshotRefresh = @($nearbyRows | Where-Object {
+        $_.EventKind -eq "tool_snapshot" -or $_.Stage -eq "tool_snapshot"
+    }).Count -gt 0
+    $hasReloadHint = @($nearbyRows | Where-Object {
+        $_.SnapshotReason -match "reload|compile|domain|bridge_started"
+    }).Count -gt 0
+
+    if ($hasNewConnection -and ($hasSnapshotRefresh -or $hasReloadHint)) {
+        return "domain_reload_transport_close"
+    }
+
+    if ($hasNewConnection) {
+        return "transport_reconnect_after_request"
+    }
+
+    if ($hasSnapshotRefresh) {
+        return "snapshot_refresh_after_request"
+    }
+
+    return "unmatched_request"
+}
+
 function Get-MeasureSum {
     param(
         $InputObject,
@@ -222,6 +294,12 @@ Get-Content -LiteralPath $resolvedStatsPath | ForEach-Object {
         $commandType = if ($entry.commandType) { Get-StringValue -Value $entry.commandType } else { Get-StringValue -Value $entry.name }
         $discoveryMode = if ($entry.discoveryMode) { Get-StringValue -Value $entry.discoveryMode } else { Get-StringValue -Value $entry.toolDiscoveryMode }
         $snapshotReason = if ($entry.snapshotReason) { Get-StringValue -Value $entry.snapshotReason } else { Get-StringValue -Value $entry.toolDiscoveryReason }
+        $manifestKind = if ($entry.manifestKind) { Get-StringValue -Value $entry.manifestKind } else { Get-StringValue -Value $entry.meta.manifestKind }
+        $manifestReason = if ($entry.manifestReason) { Get-StringValue -Value $entry.manifestReason } else { Get-StringValue -Value $entry.meta.manifestReason }
+        $activeToolPacks = if ($entry.activeToolPacks) { Get-PackListString -Value $entry.activeToolPacks } else { Get-PackListString -Value $entry.meta.activeToolPacks }
+        $bridgeSessionId = if ($entry.bridgeSessionId) { Get-StringValue -Value $entry.bridgeSessionId } else { Get-StringValue -Value $entry.meta.bridgeSessionId }
+        $manifestVersion = if ($entry.manifestVersion) { Get-NumberValue -Value $entry.manifestVersion } else { Get-NumberValue -Value $entry.meta.manifestVersion }
+        $responseStatus = if ($entry.responseStatus) { Get-StringValue -Value $entry.responseStatus } elseif ($entry.status) { Get-StringValue -Value $entry.status } else { Get-StringValue -Value $entry.meta.status }
 
         $rows.Add([pscustomobject]@{
             TimestampUtc        = $timestamp
@@ -265,6 +343,12 @@ Get-Content -LiteralPath $resolvedStatsPath | ForEach-Object {
             SnapshotHashFull    = Get-StringValue -Value $entry.snapshotHashFull
             EnabledToolCount    = Get-NumberValue -Value $entry.enabledToolCount
             RegisteredToolCount = Get-NumberValue -Value $entry.registeredToolCount
+            BridgeSessionId     = $bridgeSessionId
+            ManifestVersion     = $manifestVersion
+            ManifestKind        = $manifestKind
+            ManifestReason      = $manifestReason
+            ActiveToolPacks     = $activeToolPacks
+            ResponseStatus      = $responseStatus
             Meta                = $entry.meta
         })
     }
@@ -412,6 +496,100 @@ $bridgeTopCommands = @($bridgeRequestRows |
 
 $bridgeLatencySummary = New-LatencySummary -Rows $bridgeResponseRows
 
+$bridgeResponseKeys = @{}
+foreach ($responseRow in $bridgeResponseRows) {
+    $key = Get-BridgeRowKey -Row $responseRow
+    if ($key) {
+        $bridgeResponseKeys[$key] = $true
+    }
+}
+
+$unmatchedBridgeRequests = @($bridgeRequestRows |
+    Where-Object {
+        $key = Get-BridgeRowKey -Row $_
+        $key -and -not $bridgeResponseKeys.ContainsKey($key)
+    } |
+    Sort-Object TimestampUtc |
+    ForEach-Object {
+        [pscustomobject]@{
+            TimestampUtc   = $_.TimestampUtc
+            ConnectionId   = $_.ConnectionId
+            RequestId      = $_.RequestId
+            CommandType    = $_.CommandType
+            RequestBytes   = [int64][math]::Round($_.RequestBytes)
+            Classification = Get-UnmatchedBridgeRequestClass -RequestRow $_ -AllRows $sortedRows
+        }
+    })
+
+$connectionSummaries = @($rows |
+    Where-Object { -not [string]::IsNullOrWhiteSpace($_.ConnectionId) } |
+    Group-Object ConnectionId |
+    ForEach-Object {
+        $connectionId = $_.Name
+        $connectionRows = @($_.Group | Sort-Object TimestampUtc)
+        $requests = @($connectionRows | Where-Object { $_.Stage -eq "coverage_bridge_command_request" })
+        $responses = @($connectionRows | Where-Object { $_.Stage -eq "coverage_bridge_command_response" })
+        [pscustomobject]@{
+            ConnectionId = $connectionId
+            FirstUtc = $connectionRows[0].TimestampUtc
+            LastUtc = $connectionRows[-1].TimestampUtc
+            RequestCount = $requests.Count
+            ResponseCount = $responses.Count
+            UnmatchedRequestCount = @($unmatchedBridgeRequests | Where-Object { $_.ConnectionId -eq $connectionId }).Count
+            TopCommand = (@($requests | Group-Object CommandType | Sort-Object Count -Descending | Select-Object -First 1).Name)
+        }
+    } |
+    Sort-Object FirstUtc)
+
+$setupCycles = @()
+foreach ($connectionGroup in ($bridgeRequestRows | Sort-Object TimestampUtc | Group-Object ConnectionId)) {
+    $connectionRequests = @($connectionGroup.Group | Sort-Object TimestampUtc)
+    for ($i = 0; $i -lt $connectionRequests.Count; $i++) {
+        $registerRow = $connectionRequests[$i]
+        if ($registerRow.CommandType -ne "register_client") {
+            continue
+        }
+
+        $manifestRow = @($connectionRequests | Where-Object {
+            $_.TimestampUtc -gt $registerRow.TimestampUtc -and $_.CommandType -eq "get_manifest"
+        } | Select-Object -First 1)
+        if ($manifestRow.Count -eq 0) {
+            continue
+        }
+
+        $schemaRow = @($connectionRequests | Where-Object {
+            $_.TimestampUtc -gt $manifestRow[0].TimestampUtc -and $_.CommandType -eq "get_tool_schema"
+        } | Select-Object -First 1)
+        if ($schemaRow.Count -eq 0) {
+            continue
+        }
+
+        $setupCycles += [pscustomobject]@{
+            TimestampUtc = $registerRow.TimestampUtc
+            ConnectionId = $connectionGroup.Name
+            RegisterRequestId = $registerRow.RequestId
+            ManifestRequestId = $manifestRow[0].RequestId
+            SchemaRequestId = $schemaRow[0].RequestId
+        }
+    }
+}
+
+$packSetTransitions = @($bridgeResponseRows |
+    Where-Object { $_.CommandType -eq "set_tool_packs" } |
+    Sort-Object TimestampUtc |
+    ForEach-Object {
+        [pscustomobject]@{
+            TimestampUtc = $_.TimestampUtc
+            ConnectionId = $_.ConnectionId
+            RequestId = $_.RequestId
+            ActiveToolPacks = $_.ActiveToolPacks
+            ManifestKind = $_.ManifestKind
+            ManifestReason = $_.ManifestReason
+            Unchanged = $_.Unchanged
+            ResponseBytes = [int64][math]::Round($_.ResponseBytes)
+        }
+    })
+
 $toolSnapshotRows = @($rows | Where-Object { $_.EventKind -eq "tool_snapshot" -or $_.Stage -eq "tool_snapshot" })
 $orderedSnapshotRows = @($toolSnapshotRows | Sort-Object TimestampUtc)
 $minimalTransitions = 0
@@ -474,6 +652,19 @@ $report = [pscustomobject]@{
         ShapedTokens = [int64]$totalShapedTokens
         SavedTokens = [int64][math]::Max(0, $totalRawTokens - $totalShapedTokens)
         SavingsPct = Get-Percent -Part ([math]::Max(0, $totalRawBytes - $totalShapedBytes)) -Whole $totalRawBytes
+        ShapingApplicability = [pscustomobject]@{
+            PayloadRowsEligible = $payloadRows.Count
+            CoverageRowsNotApplicable = $coverageRows.Count
+            PayloadRowsWithSavings = @($payloadRows | Where-Object { $_.RawBytes -gt $_.ShapedBytes }).Count
+            NoShapingRecorded = ($totalRawBytes -gt 0 -and [int64][math]::Round($totalRawBytes) -eq [int64][math]::Round($totalShapedBytes))
+            Summary = if ($payloadRows.Count -eq 0) {
+                "No payload rows recorded; coverage rows are shaping n/a."
+            } elseif ($totalRawBytes -gt 0 -and [int64][math]::Round($totalRawBytes) -eq [int64][math]::Round($totalShapedBytes)) {
+                "No shaping recorded for eligible payload rows; coverage rows are shaping n/a."
+            } else {
+                "Payload rows are shaping eligible; coverage rows are shaping n/a."
+            }
+        }
     }
     RepeatedContextEstimate = [pscustomobject]@{
         ExactDuplicateGroups = @($exactDuplicateGroups).Count
@@ -494,12 +685,17 @@ $report = [pscustomobject]@{
     BridgeCoverage = [pscustomobject]@{
         RequestCount = $bridgeRequestRows.Count
         ResponseCount = $bridgeResponseRows.Count
+        ConnectionCount = @($connectionSummaries).Count
         DirectRequests = @($bridgeRequestRows | Where-Object { $_.Origin -eq "direct" }).Count
         GatewayRequests = @($bridgeRequestRows | Where-Object { $_.Origin -eq "gateway" }).Count
         RequestBytes = [int64][math]::Round($bridgeRequestBytes)
         ResponseBytes = [int64][math]::Round($bridgeResponseBytes)
         Latency = $bridgeLatencySummary
         TopCommands = @($bridgeTopCommands)
+        ConnectionSummaries = @($connectionSummaries)
+        SetupCycles = @($setupCycles)
+        PackSetTransitions = @($packSetTransitions)
+        UnmatchedRequests = @($unmatchedBridgeRequests)
     }
     ToolSnapshotChurn = [pscustomobject]@{
         Count = $toolSnapshotRows.Count
@@ -534,6 +730,8 @@ Write-Host ("  Raw tokens:     {0}" -f $report.Totals.RawTokens)
 Write-Host ("  Shaped tokens:  {0}" -f $report.Totals.ShapedTokens)
 Write-Host ("  Saved tokens:   {0}" -f $report.Totals.SavedTokens)
 Write-Host ("  Savings:        {0}%" -f $report.Totals.SavingsPct)
+Write-Host ("  Shaping scope:  {0}" -f $report.Totals.ShapingApplicability.Summary)
+Write-Host ("  Eligible payload rows: {0}; coverage rows shaping n/a: {1}" -f $report.Totals.ShapingApplicability.PayloadRowsEligible, $report.Totals.ShapingApplicability.CoverageRowsNotApplicable)
 Write-Host ""
 Write-Host "Repeated context estimate"
 Write-Host ("  Exact duplicate groups:      {0}" -f $report.RepeatedContextEstimate.ExactDuplicateGroups)
@@ -566,6 +764,8 @@ if ($report.RunSummaries.Count -gt 0) {
 Write-Host "Bridge coverage"
 Write-Host ("  Requests:        {0}" -f $report.BridgeCoverage.RequestCount)
 Write-Host ("  Responses:       {0}" -f $report.BridgeCoverage.ResponseCount)
+Write-Host ("  Connections:     {0}" -f $report.BridgeCoverage.ConnectionCount)
+Write-Host ("  Unmatched reqs:  {0}" -f $report.BridgeCoverage.UnmatchedRequests.Count)
 Write-Host ("  Direct requests: {0}" -f $report.BridgeCoverage.DirectRequests)
 Write-Host ("  Gateway requests:{0}" -f $report.BridgeCoverage.GatewayRequests)
 Write-Host ("  Request bytes:   {0} ({1})" -f $report.BridgeCoverage.RequestBytes, (Get-ByteString $report.BridgeCoverage.RequestBytes))
@@ -574,6 +774,34 @@ Write-Host ("  Response latency Mean / P95 ms: {0} / {1}" -f $report.BridgeCover
 if ($report.BridgeCoverage.TopCommands.Count -gt 0) {
     $report.BridgeCoverage.TopCommands |
         Format-Table Label, Count, RequestBytes -AutoSize |
+        Out-String |
+        Write-Host
+}
+
+Write-Host "Session churn"
+Write-Host ("  Setup cycles:          {0}" -f $report.BridgeCoverage.SetupCycles.Count)
+Write-Host ("  Pack-set transitions:  {0}" -f $report.BridgeCoverage.PackSetTransitions.Count)
+Write-Host ("  Unmatched requests:    {0}" -f $report.BridgeCoverage.UnmatchedRequests.Count)
+if ($report.BridgeCoverage.ConnectionSummaries.Count -gt 0) {
+    $report.BridgeCoverage.ConnectionSummaries |
+        Select-Object ConnectionId, RequestCount, ResponseCount, UnmatchedRequestCount, TopCommand |
+        Format-Table -AutoSize |
+        Out-String |
+        Write-Host
+}
+if ($report.BridgeCoverage.PackSetTransitions.Count -gt 0) {
+    Write-Host "Pack-set transitions"
+    $report.BridgeCoverage.PackSetTransitions |
+        Select-Object TimestampUtc, ConnectionId, ActiveToolPacks, ManifestKind, Unchanged, ResponseBytes |
+        Format-Table -AutoSize |
+        Out-String |
+        Write-Host
+}
+if ($report.BridgeCoverage.UnmatchedRequests.Count -gt 0) {
+    Write-Host "Unmatched bridge requests"
+    $report.BridgeCoverage.UnmatchedRequests |
+        Select-Object TimestampUtc, ConnectionId, CommandType, RequestId, Classification |
+        Format-Table -AutoSize |
         Out-String |
         Write-Host
 }

--- a/UnityMcpLensApp~/src/UnityMcpLens/Program.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens/Program.cs
@@ -205,19 +205,22 @@ sealed class UnityMcpLensHost
                 }
                 else
                 {
+                    bool unchanged = string.Equals(manifestEnvelope.Result.Kind, "unchanged", StringComparison.OrdinalIgnoreCase);
                     await ApplyManifestAsync(manifestEnvelope.Result, shouldFetchSchemas: true, cancellationToken).ConfigureAwait(false);
-                    if (m_ClientInitialized)
+                    if (!unchanged && m_ClientInitialized)
                         await SendToolsListChangedNotificationAsync(cancellationToken).ConfigureAwait(false);
 
                     result = BuildToolCallResult(JsonSerializer.SerializeToElement(new
                     {
                         success = true,
-                        message = "Updated active Unity MCP tool packs.",
+                        message = unchanged ? "Active Unity MCP tool packs unchanged." : "Updated active Unity MCP tool packs.",
                         data = new
                         {
                             activeToolPacks = manifestEnvelope.Result.ActiveToolPacks,
                             manifestVersion = manifestEnvelope.Result.ManifestVersion,
                             bridgeSessionId = manifestEnvelope.Result.BridgeSessionId,
+                            unchanged,
+                            manifestKind = manifestEnvelope.Result.Kind,
                             toolCount = m_ToolCache.Count
                         }
                     }, m_JsonOptions));


### PR DESCRIPTION
## Summary

This PR adds a narrow dogfood telemetry churn pass for Unity MCP Lens.

It makes the existing usage reports more actionable and reduces avoidable pack/schema churn without redesigning MCP session lifetime.

## Changes

- Adds Session Churn reporting to the PowerShell payload analyzer and Unity Usage Report.
- Reports bridge connection counts, setup cycles, pack-set transitions, and unmatched bridge requests.
- Classifies the dogfood unmatched `Unity_ManageEditor` request as a likely compile/domain-reload transport close.
- Clarifies payload shaping accounting by marking coverage rows as shaping n/a.
- Adds best-effort aborted bridge response telemetry when response writes fail because the transport closes.
- Makes identical `Unity.SetToolPacks` calls return `unchanged` without full manifest/schema refresh or `tools/list_changed` notification.

## Validation

- `powershell -ExecutionPolicy Bypass -File Tools~/Test-McpPackageIdentity.ps1`
- `powershell -ExecutionPolicy Bypass -File Tools~/Test-McpStandaloneBoundary.ps1`
- `powershell -ExecutionPolicy Bypass -File Tools~/Test-McpToolOwnership.ps1`
- `powershell -ExecutionPolicy Bypass -File Tools~/Test-McpLensPresentation.ps1`
- `dotnet build UnityMcpLensApp~/src/UnityMcpLens/UnityMcpLens.csproj`
- `dotnet build Tools~/UnityMcpLensPackSwitchBenchApp~/UnityMcpLensPackSwitchBench.csproj`
- Ran analyzer against `D:\unity-mcp-lens-fresh-import-20260420-131221\Library\AI.Gateway.PayloadStats.jsonl` and verified 192 requests, 191 responses, one unmatched request classified as `domain_reload_transport_close`, and coverage rows reported as shaping n/a.
- Live fresh-project probe verified second identical `Unity.SetToolPacks(console)` returned `unchanged=true`, emitted zero `tools/list_changed` notifications, and produced zero schema requests.
- `Unity.ReadConsole` returned 0 entries after the probe.