### PR TITLE
Refactor editor stability result handling and improve payload shaping

### DIFF
--- a/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/SKILL.md
@@ -80,6 +80,7 @@ or YAML edits.
 8. Prefer direct MCP tools through the Lens path by default.
    - Use helper scripts for orchestration-heavy flows such as long builds, autoplay, or deterministic screenshot capture.
    - Those helper scripts must also stay on the Lens path; do not bounce into legacy relay or stale fallback behavior.
+   - When a known workflow needs multiple project/ui/scene/debug calls, prefer `scripts/Invoke-UnityMcpBatch.js` on macOS/Linux or `scripts/Invoke-UnityMcpBatch.ps1` on Windows so the steps share one Lens session.
 9. For large tool outputs, prefer summary/preview first.
    - If a result exposes `detailRef`, call `Unity.ReadDetailRef` only when the preview is insufficient.
    - Do not immediately expand every large payload.
@@ -125,14 +126,15 @@ or YAML edits.
 26. For measured HUD/layout assertions such as inside-screen, right-of, below, below-center, or ordered-stack checks, use `scripts/Verify-UnityUiScreenLayout.ps1` or `Unity.UI.VerifyScreenLayout`.
    - Keep strict `right_of`, `left_of`, `above`, and `below` for non-overlap rect semantics.
    - Use `right_of_center`, `left_of_center`, `above_center`, or `below_center` for “visually higher/lower within the same card” cases such as count labels inside HUD slots.
-27. If a `Unity_RunCommand` starts a long WebGL build on Windows, pass `-MonitorBuildMode WebGL` plus any known output/report/artifact paths so the PowerShell helper can fall back to passive log/disk monitoring when MCP stdout becomes unreliable. On macOS/Linux, launch the build with the JS helper, then use the session check build monitor and `Editor.log` while the build is active.
-28. For autoplay or scripted validation, use `scripts/Run-UnityAutoplayPlaytest.ps1`.
-29. For screenshots, use `scripts/Capture-UnityPlaytestArtifacts.js` on macOS/Linux or `scripts/Capture-UnityPlaytestArtifacts.ps1` on Windows. It waits for idle, supports pre-capture state locks, prefers relative project paths, and falls back to desktop capture when Unity-aware capture is flaky.
-30. When a scene looks correct in edit mode but different in play mode, treat runtime ownership drift as the default suspect before retuning values. Read `references/authoring-drift.md` and use a small runtime probe to compare the same fields in edit mode and play mode.
-31. For score, initials, or other first-run gating backed by `PlayerPrefs`, distinguish a missing key from a saved `0` value. Use `HasKey` when deciding whether a flow is truly first-run.
-32. When reading Unity console output, treat known MCP/package chatter as bridge self-noise unless real compiler or gameplay errors are mixed in.
-33. For package/import/Input System failures, activate `project` and run `Unity.Project.PackageCompatibility`, `Unity.InputActions.InspectAsset`, or `Unity.InputSystem.Diagnostics` before editing `ProjectSettings.asset`, grepping `Editor.log`, or writing a custom probe.
-34. For active input backend changes, use the preview/apply ProjectSettings tools and verify readback before restarting Unity.
+27. For repeated smoke/workflow sequences, use `scripts/Invoke-UnityMcpBatch.js` or `scripts/Invoke-UnityMcpBatch.ps1` with an ordered JSON step list. Keep per-step outputs compact and read `detailRef` only when the passing summary is insufficient.
+28. If a `Unity_RunCommand` starts a long WebGL build on Windows, pass `-MonitorBuildMode WebGL` plus any known output/report/artifact paths so the PowerShell helper can fall back to passive log/disk monitoring when MCP stdout becomes unreliable. On macOS/Linux, launch the build with the JS helper, then use the session check build monitor and `Editor.log` while the build is active.
+29. For autoplay or scripted validation, use `scripts/Run-UnityAutoplayPlaytest.ps1`.
+30. For screenshots, use `scripts/Capture-UnityPlaytestArtifacts.js` on macOS/Linux or `scripts/Capture-UnityPlaytestArtifacts.ps1` on Windows. It waits for idle, supports pre-capture state locks, prefers relative project paths, and falls back to desktop capture when Unity-aware capture is flaky.
+31. When a scene looks correct in edit mode but different in play mode, treat runtime ownership drift as the default suspect before retuning values. Read `references/authoring-drift.md` and use a small runtime probe to compare the same fields in edit mode and play mode.
+32. For score, initials, or other first-run gating backed by `PlayerPrefs`, distinguish a missing key from a saved `0` value. Use `HasKey` when deciding whether a flow is truly first-run.
+33. When reading Unity console output, treat known MCP/package chatter as bridge self-noise unless real compiler or gameplay errors are mixed in.
+34. For package/import/Input System failures, activate `project` and run `Unity.Project.PackageCompatibility`, `Unity.InputActions.InspectAsset`, or `Unity.InputSystem.Diagnostics` before editing `ProjectSettings.asset`, grepping `Editor.log`, or writing a custom probe.
+35. For active input backend changes, use the preview/apply ProjectSettings tools and verify readback before restarting Unity.
 
 ## Scene Debugger Pattern
 
@@ -167,6 +169,7 @@ Prefer a scene-owned debugger component when a project needs fast UI or state it
 - Prefer split GameObject TSAM tools before legacy `Unity.ManageGameObject`
 - Prefer Phase 11 `project` tools for package/import/Input System diagnostics and active input handler changes
 - Prefer Phase 12 `ui` and scene-binding tools for persistent HUD authoring, scene reference binding, and screen-layout verification before custom editor-side `Unity_RunCommand`
+- Prefer `Invoke-UnityMcpBatch` for repeated multi-step smoke/workflow checks that span packs
 - Expand packs explicitly, not heuristically
 - Use `Unity.GetLensUsageReport` in `debug` for telemetry baselines, appended smoke rows, and TSAM stage coverage
 - Session and bridge checks are compact by default; use `-IncludeDiagnostics` only for explicit maintenance

--- a/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Invoke-UnityMcpBatch.ps1
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Invoke-UnityMcpBatch.ps1
@@ -1,0 +1,33 @@
+param(
+    [string]$ProjectPath = (Get-Location).Path,
+    [Parameter()][string]$StepsJson,
+    [Parameter()][string]$StepsPath,
+    [int]$TimeoutSeconds = 45
+)
+
+. "$PSScriptRoot\UnityDevCommon.ps1"
+
+if ([string]::IsNullOrWhiteSpace($StepsJson) -and [string]::IsNullOrWhiteSpace($StepsPath)) {
+    throw "Provide -StepsJson or -StepsPath."
+}
+
+$nodePath = (Get-Command node -ErrorAction Stop).Source
+$bridgeScriptsDir = Join-Path (Get-UnityBridgeSkillPath) "scripts"
+$scriptPath = Join-Path $bridgeScriptsDir "Invoke-UnityMcpBatch.js"
+$resolvedProjectPath = Resolve-UnityProjectPath -ProjectPath $ProjectPath
+
+$scriptArgs = @(
+    $scriptPath,
+    "--ProjectPath", $resolvedProjectPath,
+    "--TimeoutSeconds", [string]$TimeoutSeconds
+)
+
+if (-not [string]::IsNullOrWhiteSpace($StepsPath)) {
+    $scriptArgs += @("--StepsPath", (Resolve-Path -LiteralPath $StepsPath).Path)
+}
+else {
+    $scriptArgs += @("--StepsJson", $StepsJson)
+}
+
+& $nodePath @scriptArgs
+exit $LASTEXITCODE

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/SKILL.md
@@ -86,6 +86,7 @@ powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
 - At most two additional non-foundation packs should be active at once.
 - When a tool result includes `detailRef`, use `Unity.ReadDetailRef` only when the preview/summary is insufficient. Do not immediately expand every large result.
 - `Unity.RunCommand` and `Unity.ManageEditor WaitForStableEditor` are expected to return compact, stage-aware results. Treat detail refs as the source for full logs or full editor-state attempts when needed.
+- For known multi-step smoke or workflow sequences, prefer `Invoke-UnityMcpBatch` so one Lens session can activate the needed exact pack sets and avoid repeated schema/session churn.
 
 ## Classification Rules
 
@@ -106,6 +107,7 @@ powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
 ## Diagnostics
 
 - Compact output is the default operator view. Reach for diagnostics mode only when the maintenance task actually requires raw editor detail.
+- Compact TSAM results may include `rawBytes`, `shapedBytes`, `sha256`, `detailAvailable`, and `detailRef`; use those fields as shaping proof before expanding detail.
 - For package/import/Input System failures, prefer `project` pack tools (`Unity.Project.PackageCompatibility`, `Unity.InputActions.InspectAsset`, `Unity.InputSystem.Diagnostics`, and the active input handler preview/apply tools) before resorting to ad hoc editor probes or raw `Editor.log` grep.
 - Inspect `%USERPROFILE%\.unity\mcp\connections\bridge-status-*.json` for the current bridge status.
 - Inspect `%LOCALAPPDATA%\Unity\Editor\Editor.log` for approval, handshake, disconnect, compile, and auth signals.

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/Invoke-UnityMcpBatch.js
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/Invoke-UnityMcpBatch.js
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+
+const fs = require("fs");
+const common = require("./UnityMcpCommon");
+
+function loadSteps(args) {
+  const stepsPath = common.getArgString(args, ["StepsPath"], "");
+  const stepsJson = common.getArgString(args, ["StepsJson"], "") || process.env.UNITY_MCP_BATCH_STEPS_JSON || "";
+  if (stepsPath) {
+    return JSON.parse(fs.readFileSync(stepsPath, "utf8").replace(/^\uFEFF/, ""));
+  }
+  if (stepsJson) {
+    return JSON.parse(stepsJson);
+  }
+  throw new Error("Provide --StepsPath or --StepsJson.");
+}
+
+function normalizeStep(step, index, defaultTimeoutSeconds) {
+  const tool = common.valueOf(step, "tool", "Tool", "toolName", "ToolName");
+  if (!tool || typeof tool !== "string") {
+    throw new Error(`Batch step ${index + 1} requires a string 'tool'.`);
+  }
+
+  return {
+    name: common.valueOf(step, "name", "Name") || `step_${index + 1}`,
+    tool,
+    arguments: common.valueOf(step, "arguments", "Arguments") || {},
+    timeoutSeconds: Math.max(1, Number(common.valueOf(step, "timeoutSeconds", "TimeoutSeconds") || defaultTimeoutSeconds)),
+    expectReload: common.toBool(common.valueOf(step, "expectReload", "ExpectReload"), false),
+    continueOnError: common.toBool(common.valueOf(step, "continueOnError", "ContinueOnError"), false),
+  };
+}
+
+function compactToolResult(toolResult) {
+  if (!toolResult || typeof toolResult !== "object") {
+    return { success: false, error: "Tool returned no structured result." };
+  }
+
+  const data = common.valueOf(toolResult, "data", "Data");
+  return {
+    success: common.valueOf(toolResult, "success", "Success") === true,
+    message: common.valueOf(toolResult, "message", "Message") || null,
+    code: common.valueOf(toolResult, "code", "Code") || null,
+    error: common.valueOf(toolResult, "error", "Error") || null,
+    data,
+  };
+}
+
+function packsKey(packs) {
+  return JSON.stringify(common.inferRequiredPacks("").concat(packs || []));
+}
+
+async function main() {
+  const args = common.parseCliArgs(process.argv.slice(2));
+  const projectPath = common.resolveProjectPath(common.getArgString(args, ["ProjectPath"], process.cwd()));
+  const defaultTimeoutSeconds = common.getArgNumber(args, ["TimeoutSeconds"], 45);
+  const rawSteps = loadSteps(args);
+  if (!Array.isArray(rawSteps) || rawSteps.length === 0) {
+    throw new Error("Batch steps must be a non-empty JSON array.");
+  }
+
+  const steps = rawSteps.map((step, index) => normalizeStep(step, index, defaultTimeoutSeconds));
+  const startedAt = Date.now();
+  const results = [];
+  let previousRequiredPacksKey = packsKey([]);
+  let predictedPackTransitions = 0;
+  let success = true;
+
+  for (let index = 0; index < steps.length; index += 1) {
+    const step = steps[index];
+    const requiredPacks = common.inferRequiredPacks(step.tool);
+    const requiredPacksKey = packsKey(requiredPacks);
+    const packTransitionPredicted = requiredPacksKey !== previousRequiredPacksKey;
+    if (packTransitionPredicted) {
+      predictedPackTransitions += 1;
+      previousRequiredPacksKey = requiredPacksKey;
+    }
+
+    const stepStartedAt = Date.now();
+    try {
+      const response = await common.invokeUnityMcpToolJson(projectPath, step.tool, step.arguments, {
+        timeoutSeconds: step.timeoutSeconds,
+        allowReconnect: step.expectReload,
+        exactPacks: true,
+      });
+      const toolResult = compactToolResult(common.getToolObject(response));
+      results.push({
+        index,
+        name: step.name,
+        tool: step.tool,
+        requiredPacks,
+        packTransitionPredicted,
+        durationMs: Date.now() - stepStartedAt,
+        result: toolResult,
+      });
+
+      if (!toolResult.success) {
+        success = false;
+        if (!step.continueOnError) {
+          break;
+        }
+      }
+    } catch (error) {
+      success = false;
+      results.push({
+        index,
+        name: step.name,
+        tool: step.tool,
+        requiredPacks,
+        packTransitionPredicted,
+        durationMs: Date.now() - stepStartedAt,
+        result: {
+          success: false,
+          error: error.message,
+        },
+      });
+      if (!step.continueOnError) {
+        break;
+      }
+    }
+  }
+
+  const output = {
+    success,
+    projectPath,
+    stepCount: steps.length,
+    completedStepCount: results.length,
+    durationSeconds: Math.round(((Date.now() - startedAt) / 1000) * 1000) / 1000,
+    predictedPackTransitions,
+    results,
+  };
+
+  process.stdout.write(`${JSON.stringify(output, null, 2)}\n`);
+  await common.shutdownUnityMcpSessions();
+  process.exit(success ? 0 : 1);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  common.shutdownUnityMcpSessions().finally(() => process.exit(1));
+});

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/UnityMcpCommon.js
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/UnityMcpCommon.js
@@ -338,6 +338,18 @@ function normalizeAdditionalPacks(packs = []) {
   return normalized.slice(0, 2);
 }
 
+function stringArraysEqual(left = [], right = []) {
+  if (left.length !== right.length) {
+    return false;
+  }
+  for (let index = 0; index < left.length; index += 1) {
+    if (left[index] !== right[index]) {
+      return false;
+    }
+  }
+  return true;
+}
+
 function inferRequiredPacks(toolName) {
   const normalizedToolName = normalizeToolName(toolName);
   if (!normalizedToolName || foundationToolNames.has(normalizedToolName)) {
@@ -664,6 +676,35 @@ class UnityMcpLensSession {
 
     await this.packSetupPromise;
   }
+
+  async setExactAdditionalPacks(packs, timeoutMs = 30000) {
+    const normalizedPacks = normalizeAdditionalPacks(packs);
+    this.desiredAdditionalPacks = new Set(normalizedPacks);
+
+    const currentPacks = normalizeAdditionalPacks(Array.from(this.currentAdditionalPacks));
+    if (stringArraysEqual(currentPacks, normalizedPacks)) {
+      return {
+        skipped: true,
+        packs: normalizedPacks,
+      };
+    }
+
+    await this.ensureStarted(timeoutMs);
+    const activePacks = normalizeAdditionalPacks(Array.from(this.currentAdditionalPacks));
+    if (stringArraysEqual(activePacks, normalizedPacks)) {
+      return {
+        skipped: true,
+        packs: normalizedPacks,
+      };
+    }
+
+    const response = await this.setAdditionalPacksRaw(normalizedPacks, timeoutMs);
+    return {
+      skipped: false,
+      packs: normalizedPacks,
+      response,
+    };
+  }
 }
 
 const unityMcpSessions = new Map();
@@ -696,6 +737,11 @@ function getUnityMcpSession(projectPath) {
 async function ensureUnityToolPacks(projectPath, packs = [], options = {}) {
   const session = getUnityMcpSession(projectPath);
   await session.ensureAdditionalPacks(packs, Math.max(5000, Number(options.timeoutSeconds || 30) * 1000));
+}
+
+async function setUnityToolPacksExact(projectPath, packs = [], options = {}) {
+  const session = getUnityMcpSession(projectPath);
+  return await session.setExactAdditionalPacks(packs, Math.max(5000, Number(options.timeoutSeconds || 30) * 1000));
 }
 
 async function resetUnityMcpSession(projectPath) {
@@ -732,8 +778,12 @@ async function invokeUnityMcpToolJson(projectPath, toolName, toolArguments = {},
   for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
     const session = getUnityMcpSession(projectRoot);
     try {
-      if (requiredPacks.length > 0 && normalizeToolName(toolName) !== normalizeToolName("Unity.SetToolPacks")) {
-        await session.ensureAdditionalPacks(requiredPacks, Math.max(15000, timeoutSeconds * 1000));
+      if (normalizeToolName(toolName) !== normalizeToolName("Unity.SetToolPacks")) {
+        if (options.exactPacks === true) {
+          await session.setExactAdditionalPacks(requiredPacks, Math.max(15000, timeoutSeconds * 1000));
+        } else if (requiredPacks.length > 0) {
+          await session.ensureAdditionalPacks(requiredPacks, Math.max(15000, timeoutSeconds * 1000));
+        }
       }
 
       return await session.callToolRaw(toolName, toolArguments, Math.max(1000, timeoutSeconds * 1000));
@@ -2623,6 +2673,7 @@ module.exports = {
   getLensBinaryState,
   inferRequiredPacks,
   ensureUnityToolPacks,
+  setUnityToolPacksExact,
   resetUnityMcpSession,
   shutdownUnityMcpSessions,
   invokeUnityMcpToolJson,

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-lens-development/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-lens-development/SKILL.md
@@ -71,12 +71,23 @@ The current Phase 12 authoring surface adds split UI hierarchy/layout preview/ap
 - Prefer `Unity.UI.VerifyScreenLayout` for measured HUD/layout assertions instead of ad hoc screen-rect probes.
 - Keep `Unity.Scene.SetSerializedProperties` as the low-level fallback, not the first authoring path.
 
+## Phase 14 Payload And Batch Helper Truth
+
+Phase 14 keeps the public tool surface stable and makes high-volume TSAM results compact by default.
+
+- Compact default results are expected for `Unity.InputSystem.Diagnostics`, UI hierarchy preview/apply, scene serialized-reference binding preview/apply, and `Unity.UI.VerifyScreenLayout`.
+- Full bulky data should remain available through `detailRef` when the bridge detail store is available.
+- Use `Invoke-UnityMcpBatch` for focused smoke/workflow sequences that need multiple project/ui/scene/debug calls in one Lens session.
+- Pack baselines remain unchanged: `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
+- Current Phase 14 smoke baseline: `NoShapingRecorded=false`, `7` saving rows, `50,566` raw bytes -> `24,025` shaped bytes, `3` connections, `6` schema requests, and `4` pack transitions.
+
 ## Maintenance Rules
 
 - Any pack membership change must update the metadata audit expected counts and required-tool assertions.
 - Any TSAM-covered tool path must emit `normalization`, `service`, `adapter`, and `result_shaping` telemetry rows.
 - `Unity.RunCommand` result metadata must distinguish validation, compilation, execution, result serialization, and transport/unknown failures.
 - `Unity.ManageEditor WaitForStableEditor` should keep inline output compact and store full attempt/state detail behind detail refs.
+- New compact-result work should preserve pass/fail decision data inline and move only bulky evidence/readback arrays behind detail refs.
 - Smoke prompts must cover split tools, the legacy facade, metadata annotations, usage telemetry, and the `MeshFilter.mesh` edit-mode warning regression.
 - Commit package behavior fixes separately from skill/plugin hygiene changes.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ All notable Unity MCP Lens package changes are documented here.
 - Added Lens usage reporting for payload, bridge, pack transition, tool snapshot, and TSAM stage coverage analysis.
 - Added metadata audit coverage for foundation, scene, ui, project, and debug pack surfaces, including required tools, schema checks, and read-only annotations.
 - Added center-based `Unity.UI.VerifyScreenLayout` relative-position relations: `right_of_center`, `left_of_center`, `above_center`, and `below_center`.
+- Added `Invoke-UnityMcpBatch` repo-local helpers for ordered multi-tool smoke/workflow calls that reuse one Lens session.
 
 ### Changed
 
@@ -35,11 +36,13 @@ All notable Unity MCP Lens package changes are documented here.
 - Improved payload accounting so tool snapshot rows and usage-report rows can record the actual shaped payload size instead of reporting only raw source-object size.
 - Improved `Unity.GetLensUsageReport` findings with a positive shaping signal and top-savings summaries when eligible rows record `rawBytes > shapedBytes`.
 - Reduced helper recovery-path churn by deriving compact editor readiness from `Unity.GetLensHealth` when direct MCP health is enough.
+- Improved compact default results for Input System diagnostics, UI hierarchy preview/apply, scene serialized-reference binding preview/apply, and UI screen-layout verification, with full data preserved behind detail refs.
+- Reduced repeated smoke/session churn by allowing the batch helper to switch exact pack sets inside one Lens session instead of launching separate helper processes.
 
 ### Known Follow-Up
 
-- Reduce helper-script session/setup churn, repeated `get_tool_schema` requests, and pack transition noise.
-- Continue payload shaping for large tool execution/result rows, especially UI verify, scene binding, Input System diagnostics, and `Unity.ManageEditor`.
+- Use the batch helper for repeated smoke/workflow paths while keeping individual helper scripts stable for one-off tasks.
+- Continue payload shaping for log-heavy `Unity.RunCommand`, console results, and remaining `Unity.ManageEditor` edge cases.
 - Decide whether default package assembly filtering should exclude doc/sample/test-support asmdefs from compact compatibility reads.
 - Reduce reconnect-prone `Unity_ManageEditor` transport-noise during play transitions.
 - Add reliable editor restart/reload orchestration and prefab/serialized-reference authoring workflows.
@@ -49,10 +52,12 @@ All notable Unity MCP Lens package changes are documented here.
 - Phase 11 smoke passed with a residual payload-shaping warning on Unity `6000.4.3f1` in `D:\2DUnityNewGame`.
 - Phase 12 helper-driven hardening smoke passed with a residual payload-shaping warning on Unity `6000.4.3f1` in `D:\2DUnityNewGame`.
 - Phase 13 payload-shaping smoke passed the primary shaping target on Unity `6000.4.3f1` in `D:\2DUnityNewGame`: `NoShapingRecorded=false`, `89,643` bytes saved (`42.58%`) in the focused scope, and tool snapshot shaping reduced `100,016` raw bytes to `9,481` shaped bytes.
+- Phase 14 compact-result and batch-helper smoke passed on Unity `6000.4.3f1` in `D:\2DUnityNewGame`: `NoShapingRecorded=false`, `26,541` bytes saved (`52.49%`) in the focused scope, `7` saving rows, and batch churn reduced to `3` connections, `6` schema requests, and `4` pack transitions.
 - Metadata audit passed with `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
 - Phase 11 package compatibility, input-actions inspection, diagnostics, preview, and set calls emitted complete TSAM stage coverage with no failure classes.
 - Phase 12 UI hierarchy, scene binding, layout, and verify calls emitted complete TSAM stage coverage with no tool failure rows in the focused helper-driven scope.
 - Phase 13 focused smoke emitted complete TSAM stage coverage with no failure rows for Input System diagnostics, UI hierarchy preview/apply, scene binding preview/apply, UI layout preview/apply, and UI verify.
+- Phase 14 focused batch smoke emitted complete TSAM stage coverage with no failure rows for Input System diagnostics, UI hierarchy preview/apply, scene binding preview/apply, UI layout preview/apply, and UI verify.
 
 ## [0.1.0-alpha.1] - 2026-04-20
 

--- a/Editor/Lens/Lens/ToolResultCompactor.cs
+++ b/Editor/Lens/Lens/ToolResultCompactor.cs
@@ -1,3 +1,5 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
 using Becool.UnityMcpLens.Editor.ToolRegistry;
 using Becool.UnityMcpLens.Editor.Utils;
 
@@ -58,6 +60,62 @@ namespace Becool.UnityMcpLens.Editor.Lens
                 PayloadBudgeting.EstimateTokensFromBytes(previewBytes),
                 budgeted.Sha256);
             return budgeted;
+        }
+
+        public static object ShapeStructuredPayload(
+            string toolName,
+            object rawData,
+            object compactData,
+            object detailRefMeta = null,
+            string payloadClass = "structured_tool_result")
+        {
+            var rawJson = JsonConvert.SerializeObject(rawData, Formatting.None);
+            var rawBytes = PayloadBudgeting.GetUtf8ByteCount(rawJson);
+            var detailRef = CreateStoredDetailRef(toolName, rawData, rawBytes, detailRefMeta);
+            var shaped = ToObject(compactData);
+            shaped["detailAvailable"] = detailRef != null;
+            if (detailRef != null)
+                shaped["detailRef"] = JToken.FromObject(detailRef);
+            shaped["rawBytes"] = rawBytes;
+            shaped["sha256"] = PayloadBudgeting.ComputeSha256(rawJson);
+
+            string shapedJson = null;
+            int shapedBytes = 0;
+            for (int i = 0; i < 3; i++)
+            {
+                shaped["shapedBytes"] = shapedBytes;
+                shapedJson = shaped.ToString(Formatting.None);
+                int nextBytes = PayloadBudgeting.GetUtf8ByteCount(shapedJson);
+                if (nextBytes == shapedBytes)
+                    break;
+                shapedBytes = nextBytes;
+            }
+
+            shaped["shapedBytes"] = shapedBytes;
+            shapedJson = shaped.ToString(Formatting.None);
+            shapedBytes = PayloadBudgeting.GetUtf8ByteCount(shapedJson);
+
+            PayloadStats.RecordText(
+                "tool_result",
+                toolName,
+                rawJson,
+                shapedJson,
+                meta: new
+                {
+                    rawBytes,
+                    shapedBytes,
+                    compacted = shapedBytes < rawBytes
+                },
+                options: new PayloadStatOptions
+                {
+                    EventKind = "tool_result",
+                    RepresentationKind = "compact",
+                    PayloadClass = payloadClass,
+                    Success = true,
+                    DetailAvailable = detailRef != null
+                });
+
+            return shaped;
         }
 
         public static object ShapeJsonPayload(
@@ -134,6 +192,18 @@ namespace Becool.UnityMcpLens.Editor.Lens
                 tool = toolName,
                 bytes = rawBytes
             };
+        }
+
+        static JObject ToObject(object data)
+        {
+            if (data == null)
+                return new JObject();
+
+            JToken token = data is JToken jToken
+                ? jToken.DeepClone()
+                : JToken.FromObject(data);
+
+            return token as JObject ?? new JObject { ["value"] = token };
         }
     }
 }

--- a/Editor/Lens/Tools/ManageEditor.cs
+++ b/Editor/Lens/Tools/ManageEditor.cs
@@ -672,7 +672,6 @@ Returns:
                         }
 
                         BridgeStatusTracker.MarkReady();
-                        var inlineAttempts = CreateInlineStabilityAttempts(attempts);
                         var resultData = new EditorStabilityResultData
                         {
                             IsStable = true,
@@ -682,8 +681,8 @@ Returns:
                             BlockingReasons = blockingReasons,
                             AttemptCount = attempts.Count,
                             StableAttemptCount = attempts.Count(attempt => attempt.IsStable),
-                            InlineAttemptCount = inlineAttempts.Count,
-                            Attempts = inlineAttempts,
+                            InlineAttemptCount = 0,
+                            Attempts = new List<EditorStabilityAttemptData>(),
                             AttemptsDetailRef = CreateStabilityAttemptsDetailRef(attemptDetails),
                             EditorState = editorState,
                             FullStateDetailRef = editorState?.FullStateDetailRef,
@@ -702,7 +701,6 @@ Returns:
 
             var finalBlockingReasons = EditorStabilityUtility.GetBlockingReasons();
             editorState = BuildCompactEditorStateData(out fullEditorState);
-            var timeoutInlineAttempts = CreateInlineStabilityAttempts(attempts);
             var timeoutResultData = new EditorStabilityResultData
             {
                 IsStable = false,
@@ -712,8 +710,8 @@ Returns:
                 BlockingReasons = finalBlockingReasons,
                 AttemptCount = attempts.Count,
                 StableAttemptCount = attempts.Count(attempt => attempt.IsStable),
-                InlineAttemptCount = timeoutInlineAttempts.Count,
-                Attempts = timeoutInlineAttempts,
+                InlineAttemptCount = 0,
+                Attempts = new List<EditorStabilityAttemptData>(),
                 AttemptsDetailRef = CreateStabilityAttemptsDetailRef(attemptDetails),
                 EditorState = editorState,
                 FullStateDetailRef = editorState?.FullStateDetailRef,

--- a/Editor/Lens/Tools/ProjectInputSystemTools.cs
+++ b/Editor/Lens/Tools/ProjectInputSystemTools.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -281,7 +282,7 @@ Modes: legacy, inputSystem, both. Usually requires an editor restart or script r
             using (timing.Measure("result_shaping"))
             {
                 response = result.success
-                    ? Response.Success(result.message, compactSuccessData ? ToolResultCompactor.ShapeJsonPayload(toolName, result.message, result.data) : result.data)
+                    ? Response.Success(result.message, compactSuccessData ? ShapeProjectSuccessData(toolName, result.message, result.data) : result.data)
                     : Response.Error(result.message, result.errorData ?? new { errorKind = result.errorKind ?? fallbackErrorKind });
 
                 timing.SetResponseBytes(GetUtf8ByteCount(JsonConvert.SerializeObject(response, Formatting.None)));
@@ -289,6 +290,89 @@ Modes: legacy, inputSystem, both. Usually requires an editor restart or script r
 
             timing.Record(result.success, result.success ? null : result.errorKind ?? fallbackErrorKind);
             return response;
+        }
+
+        static object ShapeProjectSuccessData(string toolName, string summary, object data)
+        {
+            if (string.Equals(toolName, DiagnosticsToolName, StringComparison.Ordinal))
+            {
+                return ToolResultCompactor.ShapeStructuredPayload(
+                    toolName,
+                    data,
+                    BuildInputSystemDiagnosticsCompactData(data),
+                    detailRefMeta: new { kind = "input_system_diagnostics_full_result" },
+                    payloadClass: "input_system_diagnostics");
+            }
+
+            return ToolResultCompactor.ShapeJsonPayload(toolName, summary, data);
+        }
+
+        static object BuildInputSystemDiagnosticsCompactData(object data)
+        {
+            JObject root = JObject.FromObject(data ?? new { });
+            JObject devices = root["devices"] as JObject;
+            JArray deviceRows = devices?["devices"] as JArray ?? new JArray();
+            JObject inputActionAssets = root["inputActionAssets"] as JObject;
+            JArray assets = inputActionAssets?["assets"] as JArray ?? new JArray();
+            JObject editorLogSignals = root["editorLogSignals"] as JObject;
+            JArray logSignals = editorLogSignals?["signals"] as JArray ?? new JArray();
+            JObject defines = root["defines"] as JObject;
+            JArray symbols = defines?["symbols"] as JArray ?? new JArray();
+
+            var compactAssets = new JArray();
+            foreach (JObject asset in assets.OfType<JObject>())
+            {
+                JArray bindings = asset["bindings"] as JArray ?? new JArray();
+                compactAssets.Add(new JObject
+                {
+                    ["path"] = asset["path"]?.DeepClone(),
+                    ["exists"] = asset["exists"]?.DeepClone(),
+                    ["mapCount"] = asset["mapCount"]?.DeepClone(),
+                    ["actionCount"] = asset["actionCount"]?.DeepClone(),
+                    ["bindingCount"] = asset["bindingCount"]?.DeepClone(),
+                    ["controlSchemeCount"] = asset["controlSchemeCount"]?.DeepClone(),
+                    ["bindingReturnedCount"] = bindings.Count,
+                    ["wrapperGeneration"] = asset["wrapperGeneration"]?.DeepClone(),
+                    ["issues"] = asset["issues"]?.DeepClone() ?? new JArray()
+                });
+            }
+
+            return new
+            {
+                activeInputHandler = root["activeInputHandler"],
+                defines = defines == null ? null : new
+                {
+                    selectedBuildTargetGroup = defines["selectedBuildTargetGroup"],
+                    activeBuildTarget = defines["activeBuildTarget"],
+                    containsEnableInputSystem = defines["containsEnableInputSystem"],
+                    containsEnableLegacyInputManager = defines["containsEnableLegacyInputManager"],
+                    symbolCount = symbols.Count
+                },
+                package = root["package"],
+                assembly = root["assembly"],
+                devices = devices == null ? null : new
+                {
+                    available = devices["available"],
+                    count = devices["count"],
+                    returned = devices["returned"],
+                    sample = new JArray(deviceRows.Take(3).Select(row => row.DeepClone()))
+                },
+                inputActionAssets = inputActionAssets == null ? null : new
+                {
+                    count = inputActionAssets["count"],
+                    returned = inputActionAssets["returned"],
+                    assets = compactAssets
+                },
+                editorLogSignals = editorLogSignals == null ? null : new
+                {
+                    path = editorLogSignals["path"],
+                    exists = editorLogSignals["exists"],
+                    count = editorLogSignals["count"],
+                    returned = logSignals.Count,
+                    sample = new JArray(logSignals.Take(3).Select(row => row.DeepClone()))
+                },
+                compatibilitySignals = root["compatibilitySignals"]
+            };
         }
 
         static object HandleProjectDiagnosticsTool<TRequest>(

--- a/Editor/Lens/Tools/SceneReferenceBindingTools.cs
+++ b/Editor/Lens/Tools/SceneReferenceBindingTools.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
@@ -118,7 +119,12 @@ Supports single ObjectReference fields and object-reference arrays/lists only.";
             using (timing.Measure("result_shaping"))
             {
                 response = result.success
-                    ? Response.Success(result.message, ToolResultCompactor.ShapeJsonPayload(toolName, result.message, result.data))
+                    ? Response.Success(result.message, ToolResultCompactor.ShapeStructuredPayload(
+                        toolName,
+                        result.data,
+                        BuildCompactData(result.data),
+                        detailRefMeta: new { kind = "scene_reference_binding_full_result" },
+                        payloadClass: "scene_reference_binding"))
                     : Response.Error(result.message, result.errorData ?? new { errorKind = result.errorKind ?? fallbackErrorKind });
 
                 timing.SetResponseBytes(GetUtf8ByteCount(JsonConvert.SerializeObject(response, Formatting.None)));
@@ -126,6 +132,57 @@ Supports single ObjectReference fields and object-reference arrays/lists only.";
 
             timing.Record(result.success, result.success ? null : result.errorKind ?? fallbackErrorKind);
             return response;
+        }
+
+        static object BuildCompactData(object data)
+        {
+            JObject root = JObject.FromObject(data ?? new { });
+            JArray bindings = root["bindings"] as JArray ?? new JArray();
+            var bindingTypeCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var changedBindings = new JArray();
+            int unchangedCount = 0;
+
+            foreach (JObject binding in bindings.OfType<JObject>())
+            {
+                string bindingType = (string)binding["bindingType"] ?? "unknown";
+                bindingTypeCounts[bindingType] = bindingTypeCounts.TryGetValue(bindingType, out int count) ? count + 1 : 1;
+
+                bool willModify = binding["willModify"]?.Value<bool>() == true;
+                bool applied = binding["applied"]?.Value<bool>() == true;
+                if (!willModify && !applied)
+                {
+                    unchangedCount++;
+                    continue;
+                }
+
+                changedBindings.Add(new JObject
+                {
+                    ["targetPath"] = binding["targetPath"]?.DeepClone(),
+                    ["hierarchyPath"] = binding["hierarchyPath"]?.DeepClone(),
+                    ["componentType"] = binding["componentType"]?.DeepClone(),
+                    ["componentIndex"] = binding["componentIndex"]?.DeepClone(),
+                    ["propertyPath"] = binding["propertyPath"]?.DeepClone(),
+                    ["bindingType"] = binding["bindingType"]?.DeepClone(),
+                    ["willModify"] = binding["willModify"]?.DeepClone(),
+                    ["applied"] = binding["applied"]?.DeepClone(),
+                    ["requestedReference"] = binding["requestedReference"]?.DeepClone(),
+                    ["readbackReference"] = binding["readbackReference"]?.DeepClone(),
+                    ["requestedReferences"] = binding["requestedReferences"]?.DeepClone(),
+                    ["readbackReferences"] = binding["readbackReferences"]?.DeepClone()
+                });
+            }
+
+            return new
+            {
+                target = root["target"],
+                applied = root["applied"],
+                willModify = root["willModify"],
+                bindingCount = bindings.Count,
+                bindingTypeCounts,
+                changedBindingCount = changedBindings.Count,
+                omittedUnchangedBindingCount = unchangedCount,
+                changedBindings
+            };
         }
 
         static string GetString(JObject parameters, params string[] names)

--- a/Editor/Lens/Tools/UiSplitTools.cs
+++ b/Editor/Lens/Tools/UiSplitTools.cs
@@ -1,5 +1,6 @@
 #nullable disable
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using Newtonsoft.Json;
@@ -337,7 +338,7 @@ Supports inside-screen, relative-position, axis-alignment, and ordered-stack ass
             using (timing.Measure("result_shaping"))
             {
                 response = result.success
-                    ? Response.Success(result.message, ToolResultCompactor.ShapeJsonPayload(toolName, result.message, result.data))
+                    ? Response.Success(result.message, ShapeSuccessData(toolName, result.data))
                     : Response.Error(result.message, result.errorData ?? new { errorKind = result.errorKind ?? fallbackErrorKind });
 
                 timing.SetResponseBytes(GetUtf8ByteCount(JsonConvert.SerializeObject(response, Formatting.None)));
@@ -345,6 +346,132 @@ Supports inside-screen, relative-position, axis-alignment, and ordered-stack ass
 
             timing.Record(result.success, result.success ? null : result.errorKind ?? fallbackErrorKind);
             return response;
+        }
+
+        static object ShapeSuccessData(string toolName, object data)
+        {
+            if (string.Equals(toolName, PreviewEnsureHierarchyToolName, StringComparison.Ordinal) ||
+                string.Equals(toolName, ApplyEnsureHierarchyToolName, StringComparison.Ordinal))
+            {
+                return ToolResultCompactor.ShapeStructuredPayload(
+                    toolName,
+                    data,
+                    BuildEnsureHierarchyCompactData(data),
+                    detailRefMeta: new { kind = "ui_ensure_hierarchy_full_result" },
+                    payloadClass: "ui_ensure_hierarchy");
+            }
+
+            if (string.Equals(toolName, VerifyScreenLayoutToolName, StringComparison.Ordinal))
+            {
+                return ToolResultCompactor.ShapeStructuredPayload(
+                    toolName,
+                    data,
+                    BuildVerifyScreenLayoutCompactData(data),
+                    detailRefMeta: new { kind = "ui_verify_screen_layout_full_result" },
+                    payloadClass: "ui_verify_screen_layout");
+            }
+
+            return ToolResultCompactor.ShapeJsonPayload(toolName, "UI operation completed.", data);
+        }
+
+        static object BuildEnsureHierarchyCompactData(object data)
+        {
+            JObject root = JObject.FromObject(data ?? new { });
+            JArray nodes = root["nodes"] as JArray ?? new JArray();
+            var actionCounts = new Dictionary<string, int>(StringComparer.OrdinalIgnoreCase);
+            var changedNodes = new JArray();
+            int preservedCount = 0;
+
+            foreach (JObject node in nodes.OfType<JObject>())
+            {
+                string action = (string)node["action"] ?? "unknown";
+                actionCounts[action] = actionCounts.TryGetValue(action, out int count) ? count + 1 : 1;
+
+                bool hasChanges = node["changes"] is JArray changes && changes.Count > 0;
+                if (string.Equals(action, "preserve", StringComparison.OrdinalIgnoreCase) && !hasChanges)
+                {
+                    preservedCount++;
+                    continue;
+                }
+
+                changedNodes.Add(new JObject
+                {
+                    ["path"] = node["path"]?.DeepClone(),
+                    ["action"] = action,
+                    ["existed"] = node["existed"]?.DeepClone(),
+                    ["componentTypes"] = node["componentTypes"]?.DeepClone(),
+                    ["changes"] = node["changes"]?.DeepClone() ?? new JArray()
+                });
+            }
+
+            return new
+            {
+                target = root["target"],
+                applied = root["applied"],
+                willModify = root["willModify"],
+                nodeCount = nodes.Count,
+                actionCounts,
+                changedNodeCount = changedNodes.Count,
+                omittedPreservedNodeCount = preservedCount,
+                changedNodes
+            };
+        }
+
+        static object BuildVerifyScreenLayoutCompactData(object data)
+        {
+            JObject root = JObject.FromObject(data ?? new { });
+            JArray targets = root["targets"] as JArray ?? new JArray();
+            JArray assertions = root["assertions"] as JArray ?? new JArray();
+            var compactTargets = new JObject();
+            var compactAssertions = new JArray();
+            var failedAssertions = new JArray();
+
+            foreach (JObject target in targets.OfType<JObject>())
+            {
+                string key = (string)target["key"];
+                if (string.IsNullOrWhiteSpace(key))
+                    continue;
+
+                compactTargets[key] = new JObject
+                {
+                    ["path"] = target["path"]?.DeepClone(),
+                    ["canvasPath"] = target["canvasPath"]?.DeepClone(),
+                    ["activeInHierarchy"] = target["activeInHierarchy"]?.DeepClone(),
+                    ["screenRect"] = target["screenRect"]?.DeepClone()
+                };
+            }
+
+            foreach (JObject assertion in assertions.OfType<JObject>())
+            {
+                var compactAssertion = new JObject
+                {
+                    ["type"] = assertion["type"]?.DeepClone(),
+                    ["targetKey"] = assertion["targetKey"]?.DeepClone(),
+                    ["otherTargetKey"] = assertion["otherTargetKey"]?.DeepClone(),
+                    ["relation"] = assertion["relation"]?.DeepClone(),
+                    ["axis"] = assertion["axis"]?.DeepClone(),
+                    ["direction"] = assertion["direction"]?.DeepClone(),
+                    ["targetKeys"] = assertion["targetKeys"]?.DeepClone(),
+                    ["passed"] = assertion["passed"]?.DeepClone(),
+                    ["actual"] = assertion["actual"]?.DeepClone(),
+                    ["message"] = assertion["message"]?.DeepClone()
+                };
+                compactAssertions.Add(compactAssertion);
+                if (assertion["passed"]?.Value<bool>() == false)
+                    failedAssertions.Add(compactAssertion.DeepClone());
+            }
+
+            return new
+            {
+                passed = root["passed"],
+                screen = root["screen"],
+                targetCount = targets.Count,
+                assertionCount = assertions.Count,
+                failedAssertionCount = failedAssertions.Count,
+                targets = compactTargets,
+                assertions = compactAssertions,
+                failedAssertions
+            };
         }
 
         static string GetString(JObject parameters, params string[] names)

--- a/README-CODEX-PATCH.md
+++ b/README-CODEX-PATCH.md
@@ -42,6 +42,7 @@ node .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Check-Un
 - Treat `Check-UnityDevSession` as a split signal: `ProceedWithLensHelpers` means the helper path is healthy, while `ProceedWithDirectLensTools` means direct MCP is healthy and only the wrapper path is degraded.
 - Prefer the Phase 11 `project` tools for package/import/Input System and active input handler work before custom `Unity_RunCommand` probes, raw `Editor.log` grep, or YAML edits.
 - Prefer the Phase 12 `ui` and split `scene` binding tools for persistent HUD hierarchy, serialized scene references, and screen-layout verification before custom `Unity_RunCommand` editor scripts.
+- Prefer `Invoke-UnityMcpBatch` for repeated smoke/workflow checks that span project, ui, scene, and debug packs, so one Lens session can cover the ordered steps.
 - Prefer helper-driven `Invoke-UnityRunCommand` for runtime probes now that it can bypass idle-wait gating in healthy play mode and preserve structured `ReturnResult(...)` payloads.
 - Keep `foundation` at `12` exported tools, `foundation + scene` at `32`, and `foundation + ui` at `22` unless a deliberate pack-surface change updates the metadata audit.
 
@@ -58,8 +59,8 @@ node .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Check-Un
 
 ## Current Dogfood Priorities
 
-- Reduce helper-script session/setup churn and repeated schema requests.
-- Continue payload shaping for large tool execution/result rows now that tool snapshots and usage reports show measurable savings.
+- Use the batch helper for repeated smoke/workflow calls instead of separate helper processes when the steps are known up front.
+- Continue payload shaping for log-heavy `Unity.RunCommand`, console, and remaining editor-state edge cases now that the large Phase 14 TSAM target results show measurable savings.
 - Reduce noisy repeated package/editor-log signals so healthy compatibility reads stay high signal.
 - Keep `Unity.ProjectSettings.PreviewActiveInputHandler` and `Unity.ProjectSettings.SetActiveInputHandler` as the editor-authored backend change path.
 - Keep `Unity.Project.PackageCompatibility` and `Unity.InputActions.InspectAsset` as the preferred package/import read surface before raw `Editor.log` grep.
@@ -104,11 +105,21 @@ Latest Phase 13 payload-shaping smoke on 2026-04-26:
 - Helper-driven UI hierarchy, scene binding, and layout no-op apply paths still return `willModify=false` and `applied=false`.
 - `Unity.UI.VerifyScreenLayout` passed in edit mode with `inside_screen`, `ordered_stack`, and `below_center`.
 
+Latest Phase 14 compact-result and batch-helper smoke on 2026-04-26:
+
+- Metadata audit passed with unchanged baselines: `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
+- The batch helper ran `9` ordered project/ui/scene/debug steps in one workflow and completed successfully.
+- Focused scope from fresh marker line `2592` contained `98` rows with `51` payload rows and `47` TSAM coverage rows.
+- Payload telemetry reported `NoShapingRecorded=false`, with `50,566` raw bytes shaped to `24,025` bytes and `26,541` bytes saved (`52.49%`).
+- `PayloadRowsWithSavings=7`; savings now include Input System diagnostics, UI hierarchy preview/apply, scene binding preview/apply, UI verify, and usage-report results.
+- Batch control-plane churn was `3` connections, `6` schema requests, `4` pack transitions, `0` tool snapshot rows, `0` unmatched requests, and `0` failure rows.
+- `Unity.ReadDetailRef` successfully read a full compacted scene-binding result detail, confirming the compact inline result did not discard audit data.
+
 Remaining follow-ups:
 
-- Payload shaping remains incomplete for large tool execution/result rows such as UI verify, scene binding, Input System diagnostics, and `Unity.ManageEditor`.
-- Helper/session churn is lower than earlier runs but still nontrivial: the Phase 13 focused scope had `12` connections, `25` schema requests, and `12` pack transitions because separate helper processes still open separate Lens sessions.
-- The only unmatched request in the Phase 13 scope was a `Unity_ManageEditor` domain-reload transport close during the expected forced script-refresh window.
+- Continue compact shaping for log-heavy `Unity.RunCommand`, console reads, and remaining `Unity.ManageEditor` edge cases.
+- Individual helper scripts still open separate sessions; prefer `Invoke-UnityMcpBatch` when a smoke/workflow has multiple known steps.
+- Some lower-level `tool_execution` rows still report `rawBytes == shapedBytes` because they record already-compacted responses; use `tool_result` savings rows for compact-result proof.
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,13 @@ Run one simple workflow:
 
 This shows the TSAM loop: narrow tool → compact result → optional expansion → telemetry.
 
+For repeated smoke or workflow checks, use the repo-local batch helper so
+multiple project/ui/scene/debug calls share one Lens session:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Invoke-UnityMcpBatch.ps1 -ProjectPath C:\Path\To\UnityProject -StepsPath C:\Path\To\steps.json
+```
+
 ---
 
 ## Example Workflow
@@ -162,7 +169,8 @@ recorded signals include:
 - Phase 11 focused smoke on Unity `6000.4.3f1`: metadata audit passed; compact rerun span was `44` rows; bridge churn was `1` connection, `0` setup cycles, and `0` unmatched requests; TSAM coverage was complete for package compatibility, input-actions inspection, diagnostics, preview, and set.
 - Phase 12 helper-driven smoke on Unity `6000.4.3f1`: metadata audit passed with `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`; rerun scope was `358` rows; bridge churn was `25` connections, `0` setup cycles, and `0` unmatched requests; TSAM coverage was complete for UI hierarchy, scene binding, layout, and verify.
 - Phase 13 payload-shaping smoke on Unity `6000.4.3f1`: rerun scope was `244` rows; payload size was `210,510` raw bytes -> `120,867` shaped bytes; recorded savings were `89,643` bytes (`42.58%`); `NoShapingRecorded=false`; the largest measured win was tool snapshot shaping at `100,016` raw bytes -> `9,481` shaped bytes.
-- Payload shaping is still underway. Phase 13 proves measurable savings for tool snapshots and usage reports, but large tool execution/result rows still need compact shaping and detail refs.
+- Phase 14 compact-result smoke on Unity `6000.4.3f1`: batch rerun scope was `98` rows; payload size was `50,566` raw bytes -> `24,025` shaped bytes; recorded savings were `26,541` bytes (`52.49%`); `7` eligible rows saved bytes; the batch helper reduced churn to `3` connections, `6` schema requests, and `4` pack transitions.
+- Payload shaping is still underway for log-heavy and edge-case surfaces, but the large Phase 14 TSAM target results now default to compact inline data with full data behind `detailRef`.
 
 Future benchmark reports should include:
 

--- a/docs/RoadMap.md
+++ b/docs/RoadMap.md
@@ -18,7 +18,7 @@ when Unity reloads, recompiles, or changes project/package state.
 - Current Phase 12 surface: split UI hierarchy/layout preview/apply, scene serialized-reference preview/apply binding, UI screen-layout verification, center-based UI verify relations, and structured `Unity.RunCommand` return values.
 - Current Phase 11 surface: project/Input System diagnostics, package compatibility, input-action asset inspection, and active input handler preview/apply.
 - Current validation surface: static package checks plus a metadata audit in the pack-switch helper app.
-- Current telemetry surface: payload stats, bridge request/response rows, tool snapshot rows, pack transition rows, and TSAM stage rows.
+- Current telemetry surface: payload stats, bridge request/response rows, compact `tool_result` savings rows, tool snapshot rows, pack transition rows, detail-ref rows, and TSAM stage rows.
 
 ---
 
@@ -75,13 +75,31 @@ A focused helper-driven Phase 12 hardening smoke then passed with a residual pay
 - `Invoke-UnityRunCommand` returned structured HUD placement data through the helper path with `playModeBypass.applied=true`.
 - The focused usage-report slice still recorded `NoShapingRecorded=true`; its only failure class was a `Unity_ManageEditor` disposed-transport response during a reconnect-prone play transition.
 
+A focused Phase 13 payload-shaping smoke then proved the first measurable
+payload accounting win:
+
+- Scope contained `244` rows with `68` payload rows and `176` TSAM coverage rows.
+- Payload size was `210,510` raw bytes -> `120,867` shaped bytes, saving `89,643` bytes (`42.58%`).
+- `NoShapingRecorded=false`.
+- Tool snapshot shaping reduced `100,016` raw bytes to `9,481` shaped bytes.
+- Residual helper churn remained: `12` connections, `25` schema requests, and `12` pack transitions.
+
+A focused Phase 14 compact-result smoke then reduced both result size and
+control-plane churn:
+
+- Scope contained `98` rows with `51` payload rows and `47` TSAM coverage rows.
+- Payload size was `50,566` raw bytes -> `24,025` shaped bytes, saving `26,541` bytes (`52.49%`).
+- `PayloadRowsWithSavings=7` across Input System diagnostics, UI hierarchy preview/apply, scene binding preview/apply, UI verify, and usage reporting.
+- The new batch helper ran `9` ordered project/ui/scene/debug steps with `3` connections, `6` schema requests, `4` pack transitions, `0` unmatched requests, and `0` failure rows.
+- Detail-ref readback was verified for a compacted full scene-binding result.
+
 ---
 
 ## Near-Term Priorities
 
 ### 1. Bridge And Session Hygiene
 
-- Reuse helper-script MCP sessions more effectively.
+- Use `Invoke-UnityMcpBatch` when a smoke or workflow has multiple known steps that can share one Lens session.
 - Avoid unnecessary pack flips and repeated setup cycles.
 - Reduce schema churn after the manifest is already known.
 - Treat domain reload transport closure as expected only when the editor state explains it.
@@ -89,10 +107,10 @@ A focused helper-driven Phase 12 hardening smoke then passed with a residual pay
 
 ### 2. Payload Shaping Correctness
 
-- Make `Unity.ManageEditor WaitForStableEditor` keep inline output compact.
-- Store full wait attempts and full editor state behind detail refs.
-- Verify payload telemetry records the shaped result, not only the raw result.
-- Keep tool snapshots compact enough that routine pack switching does not dominate context cost.
+- Keep compact TSAM results as the default for high-volume preview/apply and diagnostic tools.
+- Store full wait attempts, editor state, bindings, devices, logs, and measured geometry behind detail refs when inline data is enough for pass/fail decisions.
+- Continue compact shaping for log-heavy `Unity.RunCommand`, console results, and remaining editor-state edge cases.
+- Keep telemetry presentation clear when `tool_execution` rows record already-compacted responses and explicit `tool_result` rows carry the savings proof.
 
 ### 3. Project/Package Diagnostic Follow-Through
 

--- a/docs/TSAM.md
+++ b/docs/TSAM.md
@@ -131,6 +131,12 @@ then call `Unity.ReadDetailRef` only when the compact result is insufficient.
 This keeps routine tool calls smaller while preserving full detail for audits
 and deeper investigation.
 
+Current compact-by-default TSAM result targets include Input System diagnostics,
+UI hierarchy preview/apply, scene serialized-reference binding preview/apply,
+and UI screen-layout verification. These inline results should contain enough
+data for pass/fail decisions while moving bulky device, binding, log, corner,
+and readback rows behind `detailRef`.
+
 ---
 
 ## Telemetry Stages
@@ -146,10 +152,15 @@ TSAM tools should emit coverage rows for these stages:
 payload size, shaping metadata, bridge churn, pack transitions, tool snapshots,
 detail refs, and TSAM stage coverage.
 
-Current state: Phase 13 smoke now records `NoShapingRecorded=false` and shows
-measurable savings for tool snapshots and usage reports. Payload shaping is not
-complete; large tool execution/result rows still need compact inline forms and
-detail refs for bulky readback data.
+Current state: Phase 14 smoke records `NoShapingRecorded=false` and shows
+measurable savings for tool snapshots, usage reports, and large TSAM tool
+results. The focused Phase 14 batch smoke shaped `50,566` raw bytes to `24,025`
+bytes, saving `26,541` bytes (`52.49%`) with `7` saving rows.
+
+Use `Invoke-UnityMcpBatch` for repeated smoke/workflow calls that span packs.
+The Phase 14 batch smoke ran `9` ordered project/ui/scene/debug steps with `3`
+connections, `6` schema requests, `4` pack transitions, and no unmatched
+requests or failure rows.
 
 ---
 

--- a/docs/Telemetry
+++ b/docs/Telemetry
@@ -157,6 +157,60 @@ Smoke notes:
 - Payload shaping is now measurable for tool snapshots and usage reports, but large tool execution/result rows for UI verify, scene binding, Input System diagnostics, and `Unity.ManageEditor` still need compact result shaping.
 - Helper session churn remains visible because separate helper processes open separate Lens sessions and re-activate packs.
 
+## Phase 14 Compact TSAM And Batch Helper Smoke Baseline
+
+A focused Phase 14 smoke test on 2026-04-26 passed the compact-result and
+session-hygiene targets:
+
+- Host project: `D:\2DUnityNewGame`.
+- Unity version: `6000.4.3f1`.
+- Metadata audit: pass with `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
+- Scope: from fresh marker line `2592`, `98` rows.
+- Payload rows: `51`; coverage rows: `47`.
+- Payload size: `50,566` raw bytes -> `24,025` shaped bytes.
+- Recorded savings: `26,541` bytes, `52.49%`.
+- Shaping rows with savings: `7`.
+- `NoShapingRecorded=false`.
+
+Top savings in the focused scope:
+
+- `tool_result:Unity.Scene.ApplyBindSerializedReferences`: `7,261` raw bytes -> `466` shaped bytes, saving `6,795` bytes (`93.58%`).
+- `tool_result:Unity.Scene.PreviewBindSerializedReferences`: `7,261` raw bytes -> `468` shaped bytes, saving `6,793` bytes (`93.55%`).
+- `tool_result:Unity.UI.ApplyEnsureHierarchy`: `4,689` raw bytes -> `432` shaped bytes, saving `4,257` bytes (`90.79%`).
+- `tool_result:Unity.UI.PreviewEnsureHierarchy`: `4,689` raw bytes -> `434` shaped bytes, saving `4,255` bytes (`90.74%`).
+- `tool_result:Unity.UI.VerifyScreenLayout`: `7,394` raw bytes -> `5,085` shaped bytes, saving `2,309` bytes (`31.23%`).
+- `tool_result:Unity.InputSystem.Diagnostics`: `4,823` raw bytes -> `2,870` shaped bytes, saving `1,953` bytes (`40.49%`).
+- `tool_result:Unity.GetLensUsageReport`: `1,394` raw bytes -> `1,215` shaped bytes, saving `179` bytes (`12.84%`).
+
+Bridge/control-plane result:
+
+- The new `Invoke-UnityMcpBatch` helper ran `9` ordered project/ui/scene/debug steps in one Lens session.
+- Connections: `3`.
+- `get_tool_schema` requests: `6`.
+- Pack transitions: `4`.
+- Tool snapshot rows: `0`.
+- Unmatched requests: `0`.
+- Failure rows: `0`.
+
+TSAM coverage was complete with zero failure rows for:
+
+- `Unity.InputSystem.Diagnostics`
+- `Unity.UI.PreviewEnsureHierarchy`
+- `Unity.UI.ApplyEnsureHierarchy`
+- `Unity.Scene.PreviewBindSerializedReferences`
+- `Unity.Scene.ApplyBindSerializedReferences`
+- `Unity.UI.PreviewLayoutProperties`
+- `Unity.UI.ApplyLayoutProperties`
+- `Unity.UI.VerifyScreenLayout`
+
+Smoke notes:
+
+- Compact defaults now cover the large Phase 14 target tools: Input System diagnostics, UI hierarchy preview/apply, scene binding preview/apply, and UI verify.
+- Inline results still contain enough pass/fail data for the smoke without reading detail refs.
+- `Unity.ReadDetailRef` successfully read back a compacted full scene-binding result detail.
+- UI layout preview/apply remained small and unchanged rather than receiving artificial shaping.
+- Some lower-level `tool_execution` telemetry rows still show `rawBytes == shapedBytes` because they record the already-compacted tool response; the measured savings are now visible in explicit `tool_result` rows.
+
 ---
 
 ## Current Findings
@@ -169,22 +223,26 @@ avoid broad setup work when the editor status beacon and existing manifest are
 fresh enough.
 
 The helper path is now better at distinguishing wrapper degradation from direct
-bridge health. The focused Phase 13 scope reduced setup cycles to `0` and kept
-tool snapshot rows to `1`, but it still showed `12` connections, `25`
-`get_tool_schema` requests, and `12` pack transitions because separate helper
-processes establish separate Lens sessions. That remains a control-plane cost
-problem even though the happy path now succeeds.
+bridge health. Phase 14 added a batch helper for workflow/smoke calls that share
+one Lens session. In the focused scope, churn dropped from the Phase 13 baseline
+of `12` connections, `25` schema requests, and `12` pack transitions to `3`
+connections, `6` schema requests, and `4` pack transitions.
+
+Individual helper scripts still open separate sessions. Use the batch helper
+for repeated same-workflow reads/previews/applies when a compact smoke or
+diagnostic sequence needs multiple packs.
 
 ### Payload Shaping Gaps
 
-Phase 13 fixed the first measurable accounting gap: focused smoke now reports
-`NoShapingRecorded=false`, and tool snapshots record the compact shaped payload
-instead of only the raw source object.
+Phase 13 fixed the first measurable accounting gap for tool snapshots and usage
+reports. Phase 14 extended explicit `tool_result` shaping to large TSAM results:
+UI hierarchy preview/apply, scene binding preview/apply, UI verify, and Input
+System diagnostics now have compact inline data plus full detail refs.
 
-Remaining shaping work is still material. Large tool execution/result rows for
-UI verify, scene binding, Input System diagnostics, and `Unity.ManageEditor`
-still show `rawBytes == shapedBytes` in the focused smoke. Those tools need
-more compact inline results and detail refs for bulky readback data.
+Remaining shaping work should focus on log-heavy `Unity.RunCommand` and console
+results, any residual `Unity.ManageEditor` edge cases, and making telemetry
+presentation clearer when `tool_execution` rows record already-compacted
+responses.
 
 ### Diagnostic Surface Gaps
 

--- a/docs/unity-mcp-backlog.md
+++ b/docs/unity-mcp-backlog.md
@@ -19,7 +19,7 @@ latest dogfood findings.
 - Project-pack additions must not widen the default `foundation` surface.
 - TSAM tools must emit `normalization`, `service`, `adapter`, and `result_shaping` coverage rows.
 - The helper path now distinguishes direct MCP health from wrapper degradation, and `Invoke-UnityRunCommand` can bypass idle wait in healthy play mode.
-- Phase 13 payload telemetry now records measurable shaping savings for tool snapshots and usage reports; large tool execution/result rows remain a shaping target.
+- Phase 14 payload telemetry records measurable compact-result savings for large TSAM results, and the batch helper reduces repeated smoke/session churn.
 
 ---
 
@@ -199,6 +199,69 @@ Residual churn:
 
 ---
 
+## Latest Phase 14 Compact TSAM And Batch Helper Smoke
+
+Date: 2026-04-26
+
+Result: passed compact-result and batch-helper acceptance targets.
+
+Host project:
+
+- `D:\2DUnityNewGame`
+- Unity `6000.4.3f1`
+
+Pack/export result:
+
+- Metadata audit: pass.
+- Export counts unchanged: `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, `debug=22`.
+
+Telemetry result:
+
+- Focused scope: from fresh marker line `2592`, `98` rows.
+- Payload rows: `51`; TSAM coverage rows: `47`.
+- Payload size: `50,566` raw bytes -> `24,025` shaped bytes.
+- Recorded savings: `26,541` bytes (`52.49%`).
+- `PayloadRowsWithSavings=7`.
+- `NoShapingRecorded=false`.
+- Top savings:
+  - `Unity.Scene.ApplyBindSerializedReferences`: `7,261` raw bytes -> `466` shaped bytes, saving `6,795` bytes (`93.58%`).
+  - `Unity.Scene.PreviewBindSerializedReferences`: `7,261` raw bytes -> `468` shaped bytes, saving `6,793` bytes (`93.55%`).
+  - `Unity.UI.ApplyEnsureHierarchy`: `4,689` raw bytes -> `432` shaped bytes, saving `4,257` bytes (`90.79%`).
+  - `Unity.UI.PreviewEnsureHierarchy`: `4,689` raw bytes -> `434` shaped bytes, saving `4,255` bytes (`90.74%`).
+  - `Unity.UI.VerifyScreenLayout`: `7,394` raw bytes -> `5,085` shaped bytes, saving `2,309` bytes (`31.23%`).
+  - `Unity.InputSystem.Diagnostics`: `4,823` raw bytes -> `2,870` shaped bytes, saving `1,953` bytes (`40.49%`).
+
+Batch/session result:
+
+- `Invoke-UnityMcpBatch` ran `9` ordered project/ui/scene/debug steps in one workflow.
+- Connections: `3`.
+- `get_tool_schema` requests: `6`.
+- Pack transitions: `4`.
+- Tool snapshot rows: `0`.
+- Unmatched requests: `0`.
+- Failure rows: `0`.
+
+TSAM result:
+
+- Full TSAM coverage with zero failure rows for:
+  - `Unity.InputSystem.Diagnostics`
+  - `Unity.UI.PreviewEnsureHierarchy`
+  - `Unity.UI.ApplyEnsureHierarchy`
+  - `Unity.Scene.PreviewBindSerializedReferences`
+  - `Unity.Scene.ApplyBindSerializedReferences`
+  - `Unity.UI.PreviewLayoutProperties`
+  - `Unity.UI.ApplyLayoutProperties`
+  - `Unity.UI.VerifyScreenLayout`
+
+Smoke notes:
+
+- Compact inline outputs were enough to decide pass/fail without reading detail refs.
+- `Unity.ReadDetailRef` successfully read one full compacted scene-binding result detail.
+- UI layout result rows stayed small and did not need artificial shaping.
+- Individual helper scripts still have value for one-off tasks; use the batch helper when a smoke/workflow has multiple known steps.
+
+---
+
 ## P0
 
 ### Bridge And Helper Session Churn
@@ -212,7 +275,7 @@ Observed dogfood signals:
 
 Work:
 
-- Reuse helper-script MCP sessions where possible.
+- Use `Invoke-UnityMcpBatch` for repeated smoke/workflow calls that can share one session.
 - Avoid pack changes when the requested pack set is already active.
 - Avoid repeated schema pulls when the tool snapshot hash has not changed.
 - Make reload/play transition transport closures clear instead of alarming.
@@ -225,13 +288,14 @@ Observed dogfood signals:
 - Latest Phase 11 smoke still reported `NoShapingRecorded=true`.
 - `Unity_ManageEditor` emitted payload rows above `220 KB`.
 - Tool snapshots contributed about `2.50 MB` raw payload across `29` rows.
+- Phase 14 compact-result smoke now reports `NoShapingRecorded=false` and `7` saving rows, including UI hierarchy, scene binding, UI verify, and Input System diagnostics.
 
 Work:
 
-- Verify whether telemetry records shaped payloads or raw payloads.
 - Keep `Unity.ManageEditor WaitForStableEditor` inline output compact.
 - Store full attempts and full editor state behind detail refs.
 - Reduce routine tool snapshot payload cost.
+- Compact log-heavy `Unity.RunCommand` and console outputs next.
 
 ---
 


### PR DESCRIPTION
- Removed inline stability attempts from EditorStabilityResultData in ManageEditor.cs.
- Updated ProjectInputSystemTools.cs to introduce ShapeProjectSuccessData for better payload shaping.
- Enhanced SceneReferenceBindingTools.cs with BuildCompactData for structured result shaping.
- Improved UiSplitTools.cs with ShapeSuccessData for UI-related payload shaping.
- Added Invoke-UnityMcpBatch scripts for batch processing of Unity MCP commands.
- Updated documentation to reflect new batch helper usage and compact result shaping improvements.
- Enhanced telemetry reporting for compact results and reduced session churn in the Unity MCP workflow.