### PR TITLE
Refactor editor stability handling and improve payload shaping

### DIFF
--- a/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/SKILL.md
@@ -97,8 +97,10 @@ or YAML edits.
 14. For `Unity_RunCommand`, use `scripts/Invoke-UnityRunCommand.js` on macOS/Linux or `scripts/Invoke-UnityRunCommand.ps1` on Windows instead of hand-escaping JSON, and prefer small focused probes over one large validation script.
    - In healthy play mode, the helper should skip its own idle-wait gate and run directly.
    - Prefer `result.ReturnResult(...)` for structured probe output; do not promote probe data to warning logs just to make it visible.
+   - Treat `compilationLogs`, `executionLogs`, and `consoleLogs` as compact previews. Use `logSummary` first, then `Unity.ReadDetailRef` only when full log text is needed.
 15. For console reads, prefer direct `Unity.ReadConsole` through MCP.
    - Default to summary/small reads.
+   - Treat summary output as the decision surface: counts, grouped rows, cursor, and `detailRef`.
    - Use `Unity.ReadDetailRef` if the result was compacted and the full payload matters.
    - Reach for `scripts/Get-UnityConsole.js` on macOS/Linux or `scripts/Get-UnityConsole.ps1` on Windows only when the task explicitly needs the helper path or Lens is unavailable.
 16. For menu operations, prefer the direct Unity tool surface when available. Use `scripts/Invoke-UnityMenuItem.ps1` only when there is no direct tool or when a script is operationally safer for the specific task.

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/SKILL.md
@@ -85,7 +85,7 @@ powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
 - `foundation` is the default pack and is always on.
 - At most two additional non-foundation packs should be active at once.
 - When a tool result includes `detailRef`, use `Unity.ReadDetailRef` only when the preview/summary is insufficient. Do not immediately expand every large result.
-- `Unity.RunCommand` and `Unity.ManageEditor WaitForStableEditor` are expected to return compact, stage-aware results. Treat detail refs as the source for full logs or full editor-state attempts when needed.
+- `Unity.RunCommand`, `Unity.ReadConsole`, and `Unity.ManageEditor WaitForStableEditor` are expected to return compact, stage-aware results. Treat detail refs as the source for full logs, full scanned console entries, or full editor-state attempts when needed.
 - For known multi-step smoke or workflow sequences, prefer `Invoke-UnityMcpBatch` so one Lens session can activate the needed exact pack sets and avoid repeated schema/session churn.
 
 ## Classification Rules
@@ -108,6 +108,8 @@ powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
 
 - Compact output is the default operator view. Reach for diagnostics mode only when the maintenance task actually requires raw editor detail.
 - Compact TSAM results may include `rawBytes`, `shapedBytes`, `sha256`, `detailAvailable`, and `detailRef`; use those fields as shaping proof before expanding detail.
+- For `Unity.RunCommand`, inspect `logSummary` before expanding log detail refs.
+- For `Unity.ReadConsole`, use summary counts/grouped rows first and expand the scanned-entry detail ref only when source lines or full stack traces matter.
 - For package/import/Input System failures, prefer `project` pack tools (`Unity.Project.PackageCompatibility`, `Unity.InputActions.InspectAsset`, `Unity.InputSystem.Diagnostics`, and the active input handler preview/apply tools) before resorting to ad hoc editor probes or raw `Editor.log` grep.
 - Inspect `%USERPROFILE%\.unity\mcp\connections\bridge-status-*.json` for the current bridge status.
 - Inspect `%LOCALAPPDATA%\Unity\Editor\Editor.log` for approval, handshake, disconnect, compile, and auth signals.

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-lens-development/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-lens-development/SKILL.md
@@ -81,11 +81,23 @@ Phase 14 keeps the public tool surface stable and makes high-volume TSAM results
 - Pack baselines remain unchanged: `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
 - Current Phase 14 smoke baseline: `NoShapingRecorded=false`, `7` saving rows, `50,566` raw bytes -> `24,025` shaped bytes, `3` connections, `6` schema requests, and `4` pack transitions.
 
+## Phase 15 RunCommand And Console Truth
+
+Phase 15 keeps the public tool surface stable and makes log-heavy probe results compact by default.
+
+- `Unity.RunCommand` inline `compilationLogs`, `executionLogs`, and `consoleLogs` are short previews by default.
+- Use `logSummary` for byte counts, line counts, truncation flags, detail refs, first warning/error lines, and severity counts.
+- `Unity.ReadConsole` summary results should keep grouped rows inline and store full scanned entries behind `detailRef`.
+- `IncludeLocalFixedCode=false` must omit rewritten code inline in both `execute` and `validate` modes while preserving `localFixedCodeDetailRef`.
+- Current Phase 15 smoke baseline: `NoShapingRecorded=false`, `16,720` bytes saved, `Unity.RunCommand` saved `11,433` bytes (`65.69%`), and `Unity.ReadConsole` saved `2,219` bytes (`77.00%`).
+- Direct `Unity.ReadDetailRef` resolves RunCommand and ReadConsole details; the batch helper still needs normalization for unwrapped detail-ref responses.
+
 ## Maintenance Rules
 
 - Any pack membership change must update the metadata audit expected counts and required-tool assertions.
 - Any TSAM-covered tool path must emit `normalization`, `service`, `adapter`, and `result_shaping` telemetry rows.
 - `Unity.RunCommand` result metadata must distinguish validation, compilation, execution, result serialization, and transport/unknown failures.
+- `Unity.RunCommand` log previews must preserve enough inline summary data to decide pass/fail without forcing full detail reads.
 - `Unity.ManageEditor WaitForStableEditor` should keep inline output compact and store full attempt/state detail behind detail refs.
 - New compact-result work should preserve pass/fail decision data inline and move only bulky evidence/readback arrays behind detail refs.
 - Smoke prompts must cover split tools, the legacy facade, metadata annotations, usage telemetry, and the `MeshFilter.mesh` edit-mode warning regression.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ All notable Unity MCP Lens package changes are documented here.
 - Added metadata audit coverage for foundation, scene, ui, project, and debug pack surfaces, including required tools, schema checks, and read-only annotations.
 - Added center-based `Unity.UI.VerifyScreenLayout` relative-position relations: `right_of_center`, `left_of_center`, `above_center`, and `below_center`.
 - Added `Invoke-UnityMcpBatch` repo-local helpers for ordered multi-tool smoke/workflow calls that reuse one Lens session.
+- Added compact `Unity.RunCommand` log summaries with per-block counts, first warning/error lines, truncation flags, and detail refs.
 
 ### Changed
 
@@ -38,11 +39,14 @@ All notable Unity MCP Lens package changes are documented here.
 - Reduced helper recovery-path churn by deriving compact editor readiness from `Unity.GetLensHealth` when direct MCP health is enough.
 - Improved compact default results for Input System diagnostics, UI hierarchy preview/apply, scene serialized-reference binding preview/apply, and UI screen-layout verification, with full data preserved behind detail refs.
 - Reduced repeated smoke/session churn by allowing the batch helper to switch exact pack sets inside one Lens session instead of launching separate helper processes.
+- Improved `Unity.RunCommand` log-heavy responses so compilation, execution, and captured console logs are short previews by default with full logs behind detail refs.
+- Improved `Unity.ReadConsole` summary output so grouped rows stay inline while full scanned entries are available behind `Unity.ReadDetailRef`.
+- Improved `Unity.RunCommand` validate mode so `IncludeLocalFixedCode=false` omits rewritten code inline and preserves it behind `localFixedCodeDetailRef`.
 
 ### Known Follow-Up
 
 - Use the batch helper for repeated smoke/workflow paths while keeping individual helper scripts stable for one-off tasks.
-- Continue payload shaping for log-heavy `Unity.RunCommand`, console results, and remaining `Unity.ManageEditor` edge cases.
+- Continue payload shaping for remaining `Unity.ManageEditor` edge cases and normalize `Unity.ReadDetailRef` handling in the batch helper.
 - Decide whether default package assembly filtering should exclude doc/sample/test-support asmdefs from compact compatibility reads.
 - Reduce reconnect-prone `Unity_ManageEditor` transport-noise during play transitions.
 - Add reliable editor restart/reload orchestration and prefab/serialized-reference authoring workflows.
@@ -53,6 +57,7 @@ All notable Unity MCP Lens package changes are documented here.
 - Phase 12 helper-driven hardening smoke passed with a residual payload-shaping warning on Unity `6000.4.3f1` in `D:\2DUnityNewGame`.
 - Phase 13 payload-shaping smoke passed the primary shaping target on Unity `6000.4.3f1` in `D:\2DUnityNewGame`: `NoShapingRecorded=false`, `89,643` bytes saved (`42.58%`) in the focused scope, and tool snapshot shaping reduced `100,016` raw bytes to `9,481` shaped bytes.
 - Phase 14 compact-result and batch-helper smoke passed on Unity `6000.4.3f1` in `D:\2DUnityNewGame`: `NoShapingRecorded=false`, `26,541` bytes saved (`52.49%`) in the focused scope, `7` saving rows, and batch churn reduced to `3` connections, `6` schema requests, and `4` pack transitions.
+- Phase 15 log-compaction smoke passed on Unity `6000.4.3f1` in `D:\2DUnityNewGame`: `NoShapingRecorded=false`, `16,720` bytes saved (`29.66%`) in the focused scope, `Unity.RunCommand` saved `11,433` bytes (`65.69%`), `Unity.ReadConsole` saved `2,219` bytes (`77.00%`), with `0` unmatched requests and `0` happy-path failure rows.
 - Metadata audit passed with `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
 - Phase 11 package compatibility, input-actions inspection, diagnostics, preview, and set calls emitted complete TSAM stage coverage with no failure classes.
 - Phase 12 UI hierarchy, scene binding, layout, and verify calls emitted complete TSAM stage coverage with no tool failure rows in the focused helper-driven scope.

--- a/Editor/Lens/Tools/ReadConsole.cs
+++ b/Editor/Lens/Tools/ReadConsole.cs
@@ -57,7 +57,16 @@ Returns:
                         description = "Console log entries or grouped digests plus a cursor for incremental reads",
                         properties = new
                         {
-                            cursor = new { type = "integer", description = "Cursor to pass back on the next call" }
+                            cursor = new { type = "integer", description = "Cursor to pass back on the next call" },
+                            scannedFrom = new { type = "integer", description = "Console entry index where this read started" },
+                            entryCount = new { type = "integer", description = "Number of scanned entries that matched the filters" },
+                            groupCount = new { type = "integer", description = "Number of grouped summary rows returned" },
+                            typeCounts = new { type = "object", description = "Counts by Unity console log type" },
+                            groups = new { type = "array", description = "Grouped summary rows for Format=Summary" },
+                            detailAvailable = new { type = "boolean", description = "Whether full scanned entries are available by detail ref" },
+                            detailRef = new { type = "object", description = "Detail ref for full scanned entries when available" },
+                            rawBytes = new { type = "integer", description = "UTF-8 byte count of the full scanned entry payload" },
+                            shapedBytes = new { type = "integer", description = "UTF-8 byte count of the compact summary payload" }
                         }
                     }
                 },
@@ -529,38 +538,33 @@ Returns:
                     .Take(count ?? PayloadBudgetPolicy.MaxDiagnosticFindings)
                     .ToList();
 
-                var rawJson = Newtonsoft.Json.JsonConvert.SerializeObject(formattedEntries, Newtonsoft.Json.Formatting.None);
-                var shapedJson = Newtonsoft.Json.JsonConvert.SerializeObject(grouped, Newtonsoft.Json.Formatting.None);
-                int rawBytes = PayloadBudgeting.GetUtf8ByteCount(rawJson);
-                PayloadStats.Record("tool_result", "Unity.ReadConsole.summary", rawBytes, PayloadBudgeting.GetUtf8ByteCount(shapedJson), PayloadBudgeting.EstimateTokensFromBytes(PayloadBudgeting.GetUtf8ByteCount(shapedJson)), PayloadBudgeting.ComputeSha256(rawJson));
-                var detailRef = rawBytes > PayloadBudgetPolicy.MaxToolResultBytes
-                    ? ToolResultCompactor.CreateStoredDetailRef(
+                return Response.Success(
+                    $"Retrieved {formattedEntries.Count} console entries in summary mode.",
+                    ToolResultCompactor.ShapeStructuredPayload(
                         "Unity.ReadConsole",
                         new
                         {
                             cursor = totalEntries,
                             scannedFrom = scanStart,
+                            entryCount = formattedEntries.Count,
                             entries = formattedEntries
                         },
-                        rawBytes,
+                        new
+                        {
+                            cursor = totalEntries,
+                            scannedFrom = scanStart,
+                            entryCount = formattedEntries.Count,
+                            groupCount = grouped.Count,
+                            typeCounts = BuildTypeCounts(formattedEntries),
+                            groups = grouped
+                        },
                         new
                         {
                             format = "summary",
-                            entryCount = formattedEntries.Count
-                        })
-                    : null;
-
-                return Response.Success(
-                    $"Retrieved {formattedEntries.Count} console entries in summary mode.",
-                    new
-                    {
-                        cursor = totalEntries,
-                        scannedFrom = scanStart,
-                        entryCount = formattedEntries.Count,
-                        groups = grouped,
-                        detailAvailable = detailRef != null,
-                        detailRef
-                    }
+                            entryCount = formattedEntries.Count,
+                            groupCount = grouped.Count
+                        },
+                        "read_console_summary")
                 );
             }
 
@@ -581,6 +585,23 @@ Returns:
                         includeStacktrace,
                         entryCount = formattedEntries.Count
                     }));
+        }
+
+        static object BuildTypeCounts(IEnumerable<ConsoleLogEntry> entries)
+        {
+            var counts = entries
+                .GroupBy(entry => string.IsNullOrWhiteSpace(entry.Type) ? "Unknown" : entry.Type)
+                .ToDictionary(group => group.Key, group => group.Count(), StringComparer.OrdinalIgnoreCase);
+
+            return new
+            {
+                error = counts.TryGetValue(nameof(LogType.Error), out var errorCount) ? errorCount : 0,
+                warning = counts.TryGetValue(nameof(LogType.Warning), out var warningCount) ? warningCount : 0,
+                log = counts.TryGetValue(nameof(LogType.Log), out var logCount) ? logCount : 0,
+                exception = counts.TryGetValue(nameof(LogType.Exception), out var exceptionCount) ? exceptionCount : 0,
+                assert = counts.TryGetValue(nameof(LogType.Assert), out var assertCount) ? assertCount : 0,
+                unknown = counts.TryGetValue("Unknown", out var unknownCount) ? unknownCount : 0
+            };
         }
 
         // --- Internal Helpers ---

--- a/Editor/Lens/Tools/RunCommand.cs
+++ b/Editor/Lens/Tools/RunCommand.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
@@ -110,6 +112,11 @@ internal class CommandScript : IRunCommand
                             returnedDataIncluded = new { type = "boolean", description = "Whether returnedData is included inline." },
                             returnedDataBytes = new { type = "integer", description = "UTF-8 byte count of the serialized returnedData payload." },
                             returnedDataDetailRef = new { type = "object", description = "Detail ref for structured returnedData when omitted from the inline response." },
+                            logSummary = new { type = "object", description = "Compact per-log-block counts, first warning/error lines, truncation flags, and detail refs." },
+                            detailAvailable = new { type = "boolean", description = "Whether a full structured result detail ref is available." },
+                            detailRef = new { type = "object", description = "Detail ref for the full unshaped result payload when available." },
+                            rawBytes = new { type = "integer", description = "UTF-8 byte count of the full unshaped result payload." },
+                            shapedBytes = new { type = "integer", description = "UTF-8 byte count of the compact inline result payload." },
                             playModeExecution = new
                             {
                                 type = "object",
@@ -135,6 +142,9 @@ internal class CommandScript : IRunCommand
         /// The MCP tool name used to identify this tool in the registry.
         /// </summary>
         public const string ToolName = "Unity.RunCommand";
+
+        const int LogPreviewMaxLines = 12;
+        const int LogPreviewMaxBytes = 1536;
 
         /// <summary>
         /// Main handler for script compilation and execution.
@@ -234,6 +244,9 @@ internal class CommandScript : IRunCommand
                     responseSuccess = true;
                     responseMessage = "Command validation succeeded.";
                     var compilationLog = ShapeLogText("compilation_logs", validationResult.CompilationLogs, mode, out var compilationLogDetailRef, out var compilationLogTruncated, out var compilationLogBytes);
+                    var localFixedCodeDetailRef = includeLocalFixedCode
+                        ? null
+                        : CreateLocalFixedCodeDetailRef(validationResult.LocalFixedCode, code, mode);
                     responseData = new
                     {
                         mode,
@@ -246,7 +259,10 @@ internal class CommandScript : IRunCommand
                         compilationLogsBytes = compilationLogBytes,
                         executionLogs = string.Empty,
                         consoleLogs = string.Empty,
-                        localFixedCode = validationResult.LocalFixedCode,
+                        localFixedCode = includeLocalFixedCode ? validationResult.LocalFixedCode : null,
+                        localFixedCodeChanged = !string.Equals(validationResult.LocalFixedCode, code, StringComparison.Ordinal),
+                        localFixedCodeIncluded = includeLocalFixedCode,
+                        localFixedCodeDetailRef,
                         returnedData = (object)null,
                         returnedDataIncluded = false,
                         returnedDataBytes = 0,
@@ -449,7 +465,12 @@ internal class CommandScript : IRunCommand
                     consoleLogsDetailRef,
                     consoleLogsTruncated,
                     consoleLogsBytes,
-                    localFixedCode = validationCompleted ? validationResult.LocalFixedCode : string.Empty,
+                    localFixedCode = includeLocalFixedCode && validationCompleted ? validationResult.LocalFixedCode : null,
+                    localFixedCodeChanged = validationCompleted && !string.Equals(validationResult.LocalFixedCode, code, StringComparison.Ordinal),
+                    localFixedCodeIncluded = includeLocalFixedCode && validationCompleted,
+                    localFixedCodeDetailRef = validationCompleted && !includeLocalFixedCode
+                        ? CreateLocalFixedCodeDetailRef(validationResult.LocalFixedCode, code, mode)
+                        : null,
                     returnedData = (object)null,
                     returnedDataIncluded = false,
                     returnedDataBytes = 0,
@@ -510,7 +531,36 @@ internal class CommandScript : IRunCommand
 
                 combined["playStateRestored"] = JToken.FromObject(!shouldPauseForExecution || !restorePauseState || EditorApplication.isPaused == wasPaused);
                 combined["playModeExecution"] = JToken.FromObject(playModeExecution);
-                return combined;
+
+                string rawCompilationLogs = validationCompleted
+                    ? validationResult.CompilationLogs ?? string.Empty
+                    : string.Empty;
+                string rawExecutionLogs = executionResult.ExecutionLogs ?? string.Empty;
+                string rawConsoleLogs = executionResult.ConsoleLogs ?? string.Empty;
+
+                combined["logSummary"] = JToken.FromObject(BuildLogSummary(
+                    combined,
+                    rawCompilationLogs,
+                    rawExecutionLogs,
+                    rawConsoleLogs));
+
+                JObject rawData = (JObject)combined.DeepClone();
+                rawData["compilationLogs"] = rawCompilationLogs;
+                rawData["executionLogs"] = rawExecutionLogs;
+                rawData["consoleLogs"] = rawConsoleLogs;
+
+                return ToolResultCompactor.ShapeStructuredPayload(
+                    ToolName,
+                    rawData,
+                    combined,
+                    new
+                    {
+                        kind = "run_command_full_result",
+                        mode,
+                        failureStage = failureStage ?? "none",
+                        errorKind
+                    },
+                    "run_command_result");
             }
 
             return Task.FromResult(BuildResponse(responseSuccess, responseMessage, responseData));
@@ -544,9 +594,10 @@ internal class CommandScript : IRunCommand
         {
             text ??= string.Empty;
             bytes = PayloadBudgeting.GetUtf8ByteCount(text);
-            string preview = PayloadBudgeting.CreateTextPreview(text, 80, Math.Min(4096, PayloadBudgetPolicy.MaxToolResultBytes), out truncated);
-            detailRef = truncated
-                ? ToolResultCompactor.CreateStoredDetailRef(
+            string preview = PayloadBudgeting.CreateTextPreview(text, LogPreviewMaxLines, LogPreviewMaxBytes, out truncated);
+            detailRef = string.IsNullOrEmpty(text)
+                ? null
+                : ToolResultCompactor.CreateStoredDetailRef(
                     ToolName,
                     text,
                     bytes,
@@ -555,9 +606,122 @@ internal class CommandScript : IRunCommand
                         kind,
                         mode,
                         sha256 = PayloadBudgeting.ComputeSha256(text)
-                    })
-                : null;
+                    });
             return preview;
+        }
+
+        static object BuildLogSummary(
+            JObject compactData,
+            string compilationLogs,
+            string executionLogs,
+            string consoleLogs)
+        {
+            return new
+            {
+                compilation = BuildLogBlockSummary(
+                    compilationLogs,
+                    compactData["compilationLogsDetailRef"],
+                    compactData.Value<bool?>("compilationLogsTruncated") ?? false,
+                    compactData.Value<int?>("compilationLogsBytes") ?? 0),
+                execution = BuildLogBlockSummary(
+                    executionLogs,
+                    compactData["executionLogsDetailRef"],
+                    compactData.Value<bool?>("executionLogsTruncated") ?? false,
+                    compactData.Value<int?>("executionLogsBytes") ?? 0),
+                console = BuildLogBlockSummary(
+                    consoleLogs,
+                    compactData["consoleLogsDetailRef"],
+                    compactData.Value<bool?>("consoleLogsTruncated") ?? false,
+                    compactData.Value<int?>("consoleLogsBytes") ?? 0)
+            };
+        }
+
+        static object BuildLogBlockSummary(
+            string text,
+            JToken detailRef,
+            bool truncated,
+            int bytes)
+        {
+            var lines = SplitLogLines(text);
+            var warnings = new List<string>();
+            var errors = new List<string>();
+            int warningCount = 0;
+            int errorCount = 0;
+
+            foreach (string line in lines)
+            {
+                if (LooksLikeError(line))
+                {
+                    errorCount += 1;
+                    if (errors.Count < 3)
+                        errors.Add(TrimLine(line));
+                }
+                else if (LooksLikeWarning(line))
+                {
+                    warningCount += 1;
+                    if (warnings.Count < 3)
+                        warnings.Add(TrimLine(line));
+                }
+            }
+
+            return new
+            {
+                bytes,
+                lineCount = lines.Count,
+                previewLineLimit = LogPreviewMaxLines,
+                previewByteLimit = LogPreviewMaxBytes,
+                truncated,
+                detailAvailable = detailRef != null && detailRef.Type != JTokenType.Null,
+                detailRef = detailRef != null && detailRef.Type != JTokenType.Null ? detailRef : null,
+                severityCounts = new
+                {
+                    errors = errorCount,
+                    warnings = warningCount,
+                    info = Math.Max(0, lines.Count - errorCount - warningCount)
+                },
+                firstWarnings = warnings,
+                firstErrors = errors
+            };
+        }
+
+        static List<string> SplitLogLines(string text)
+        {
+            if (string.IsNullOrEmpty(text))
+                return new List<string>();
+
+            return text.Split(new[] { "\r\n", "\n", "\r" }, StringSplitOptions.None)
+                .Where(line => !string.IsNullOrWhiteSpace(line))
+                .ToList();
+        }
+
+        static bool LooksLikeWarning(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                return false;
+
+            return line.IndexOf("warning", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   line.IndexOf("LogWarning", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   line.StartsWith("Warning:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        static bool LooksLikeError(string line)
+        {
+            if (string.IsNullOrWhiteSpace(line))
+                return false;
+
+            return line.IndexOf("error", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   line.IndexOf("exception", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   line.IndexOf("LogError", StringComparison.OrdinalIgnoreCase) >= 0 ||
+                   line.StartsWith("Error:", StringComparison.OrdinalIgnoreCase);
+        }
+
+        static string TrimLine(string line)
+        {
+            if (string.IsNullOrEmpty(line))
+                return string.Empty;
+
+            var trimmed = line.Trim();
+            return trimmed.Length <= 240 ? trimmed : trimmed.Substring(0, 240);
         }
 
         static bool TryShapeReturnedData(

--- a/README-CODEX-PATCH.md
+++ b/README-CODEX-PATCH.md
@@ -44,6 +44,7 @@ node .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Check-Un
 - Prefer the Phase 12 `ui` and split `scene` binding tools for persistent HUD hierarchy, serialized scene references, and screen-layout verification before custom `Unity_RunCommand` editor scripts.
 - Prefer `Invoke-UnityMcpBatch` for repeated smoke/workflow checks that span project, ui, scene, and debug packs, so one Lens session can cover the ordered steps.
 - Prefer helper-driven `Invoke-UnityRunCommand` for runtime probes now that it can bypass idle-wait gating in healthy play mode and preserve structured `ReturnResult(...)` payloads.
+- Treat `Unity.RunCommand` and `Unity.ReadConsole` inline logs as compact previews. Use `logSummary` and `Unity.ReadDetailRef` only when full log text or full scanned console entries are needed.
 - Keep `foundation` at `12` exported tools, `foundation + scene` at `32`, and `foundation + ui` at `22` unless a deliberate pack-surface change updates the metadata audit.
 
 ## Current Tool Surface Reality
@@ -60,11 +61,11 @@ node .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Check-Un
 ## Current Dogfood Priorities
 
 - Use the batch helper for repeated smoke/workflow calls instead of separate helper processes when the steps are known up front.
-- Continue payload shaping for log-heavy `Unity.RunCommand`, console, and remaining editor-state edge cases now that the large Phase 14 TSAM target results show measurable savings.
+- Continue payload shaping for remaining editor-state edge cases now that the large TSAM targets and log-heavy probe/console paths show measurable savings.
 - Reduce noisy repeated package/editor-log signals so healthy compatibility reads stay high signal.
 - Keep `Unity.ProjectSettings.PreviewActiveInputHandler` and `Unity.ProjectSettings.SetActiveInputHandler` as the editor-authored backend change path.
 - Keep `Unity.Project.PackageCompatibility` and `Unity.InputActions.InspectAsset` as the preferred package/import read surface before raw `Editor.log` grep.
-- Improve `Unity.RunCommand` failure-stage metadata, detail refs, and structured `ReturnResult(...)` output.
+- Keep `Unity.RunCommand` failure-stage metadata, detail refs, compact `logSummary`, and structured `ReturnResult(...)` output stable.
 - Add reliable restart/reload orchestration with save/dirty handling and bridge reacquire.
 - Dogfood the new Phase 12 UI authoring/binding/verification path on a real host project without custom editor C#.
 
@@ -117,9 +118,20 @@ Latest Phase 14 compact-result and batch-helper smoke on 2026-04-26:
 
 Remaining follow-ups:
 
-- Continue compact shaping for log-heavy `Unity.RunCommand`, console reads, and remaining `Unity.ManageEditor` edge cases.
+- Continue compact shaping for remaining `Unity.ManageEditor` edge cases.
+- Normalize `Unity.ReadDetailRef` handling in the batch helper; direct MCP reads already resolve detail refs correctly, but the batch helper currently treats the unwrapped structured detail payload as a failed step.
 - Individual helper scripts still open separate sessions; prefer `Invoke-UnityMcpBatch` when a smoke/workflow has multiple known steps.
 - Some lower-level `tool_execution` rows still report `rawBytes == shapedBytes` because they record already-compacted responses; use `tool_result` savings rows for compact-result proof.
+
+Latest Phase 15 log-compaction smoke on 2026-04-26:
+
+- Metadata audit stayed unchanged: `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
+- Focused happy-path scope from fresh marker line `262` contained `27` rows with `6` payload rows and `21` coverage rows.
+- Payload telemetry reported `NoShapingRecorded=false`, with `56,370` raw bytes shaped to `39,650` bytes and `16,720` bytes saved (`29.66%`).
+- `Unity.RunCommand` saved `11,433` bytes (`65.69%`) in an explicit `tool_result` row while preserving `80` execution log lines and `40` captured console warning lines behind detail refs.
+- `Unity.ReadConsole` summary saved `2,219` bytes (`77.00%`) with grouped inline rows and full scanned entries behind a detail ref.
+- Direct `Unity.ReadDetailRef` resolved both the RunCommand execution-log detail payload and the ReadConsole full scanned-entry payload.
+- Expected-failure smoke confirmed `failureStage=compilation`, `failureStage=execution`, and `failureStage=result_serialization` with stable `errorKind` values and compact log summaries.
 
 ## Maintenance
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,8 @@ recorded signals include:
 - Phase 12 helper-driven smoke on Unity `6000.4.3f1`: metadata audit passed with `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`; rerun scope was `358` rows; bridge churn was `25` connections, `0` setup cycles, and `0` unmatched requests; TSAM coverage was complete for UI hierarchy, scene binding, layout, and verify.
 - Phase 13 payload-shaping smoke on Unity `6000.4.3f1`: rerun scope was `244` rows; payload size was `210,510` raw bytes -> `120,867` shaped bytes; recorded savings were `89,643` bytes (`42.58%`); `NoShapingRecorded=false`; the largest measured win was tool snapshot shaping at `100,016` raw bytes -> `9,481` shaped bytes.
 - Phase 14 compact-result smoke on Unity `6000.4.3f1`: batch rerun scope was `98` rows; payload size was `50,566` raw bytes -> `24,025` shaped bytes; recorded savings were `26,541` bytes (`52.49%`); `7` eligible rows saved bytes; the batch helper reduced churn to `3` connections, `6` schema requests, and `4` pack transitions.
-- Payload shaping is still underway for log-heavy and edge-case surfaces, but the large Phase 14 TSAM target results now default to compact inline data with full data behind `detailRef`.
+- Phase 15 log-compaction smoke on Unity `6000.4.3f1`: focused scope was `27` rows; payload size was `56,370` raw bytes -> `39,650` shaped bytes; recorded savings were `16,720` bytes (`29.66%`); `Unity.RunCommand` saved `11,433` bytes (`65.69%`) and `Unity.ReadConsole` saved `2,219` bytes (`77.00%`) in explicit `tool_result` rows.
+- Payload shaping is still underway for remaining editor-state edge cases, but the high-volume TSAM result path and log-heavy probe path now default to compact inline data with full data behind `detailRef`.
 
 Future benchmark reports should include:
 

--- a/docs/RoadMap.md
+++ b/docs/RoadMap.md
@@ -93,6 +93,15 @@ control-plane churn:
 - The new batch helper ran `9` ordered project/ui/scene/debug steps with `3` connections, `6` schema requests, `4` pack transitions, `0` unmatched requests, and `0` failure rows.
 - Detail-ref readback was verified for a compacted full scene-binding result.
 
+A focused Phase 15 compact-log smoke then covered the log-heavy probe path:
+
+- Scope contained `27` rows with `6` payload rows and `21` coverage rows.
+- Payload size was `56,370` raw bytes -> `39,650` shaped bytes, saving `16,720` bytes (`29.66%`).
+- `Unity.RunCommand` saved `11,433` bytes (`65.69%`) while preserving `80` execution log lines, `40` captured console warning lines, and structured `returnedData`.
+- `Unity.ReadConsole` summary saved `2,219` bytes (`77.00%`) with grouped inline rows and full scanned entries behind `detailRef`.
+- Direct `Unity.ReadDetailRef` read back both RunCommand and ReadConsole detail payloads.
+- Expected-failure smoke confirmed stable compilation, execution, and result-serialization failure stages and error kinds.
+
 ---
 
 ## Near-Term Priorities
@@ -109,8 +118,9 @@ control-plane churn:
 
 - Keep compact TSAM results as the default for high-volume preview/apply and diagnostic tools.
 - Store full wait attempts, editor state, bindings, devices, logs, and measured geometry behind detail refs when inline data is enough for pass/fail decisions.
-- Continue compact shaping for log-heavy `Unity.RunCommand`, console results, and remaining editor-state edge cases.
+- Continue compact shaping for remaining editor-state edge cases.
 - Keep telemetry presentation clear when `tool_execution` rows record already-compacted responses and explicit `tool_result` rows carry the savings proof.
+- Normalize batch-helper handling for `Unity.ReadDetailRef`, whose direct MCP response is healthy but currently unwrapped for the batch result normalizer.
 
 ### 3. Project/Package Diagnostic Follow-Through
 
@@ -121,7 +131,7 @@ control-plane churn:
 
 ### 4. RunCommand And Console Result Quality
 
-- Make `Unity.RunCommand` failure stage and `errorKind` unambiguous across validation, compilation, execution, result serialization, transport/unknown, and unexpected exceptions.
+- Keep `Unity.RunCommand` failure stage and `errorKind` unambiguous across validation, compilation, execution, result serialization, transport/unknown, and unexpected exceptions.
 - Dogfood `ExecutionResult.ReturnResult(...)` so focused probes no longer rely on warning-level console output to return structured measurements.
 - Keep compilation, execution, and console logs compact with detail refs for full output.
 - Add or improve structured recent-console reads so critical package/import errors do not require raw `Editor.log` grep.

--- a/docs/TSAM.md
+++ b/docs/TSAM.md
@@ -133,7 +133,8 @@ and deeper investigation.
 
 Current compact-by-default TSAM result targets include Input System diagnostics,
 UI hierarchy preview/apply, scene serialized-reference binding preview/apply,
-and UI screen-layout verification. These inline results should contain enough
+UI screen-layout verification, `Unity.RunCommand` log blocks, and
+`Unity.ReadConsole` summary reads. These inline results should contain enough
 data for pass/fail decisions while moving bulky device, binding, log, corner,
 and readback rows behind `detailRef`.
 
@@ -152,10 +153,12 @@ TSAM tools should emit coverage rows for these stages:
 payload size, shaping metadata, bridge churn, pack transitions, tool snapshots,
 detail refs, and TSAM stage coverage.
 
-Current state: Phase 14 smoke records `NoShapingRecorded=false` and shows
-measurable savings for tool snapshots, usage reports, and large TSAM tool
-results. The focused Phase 14 batch smoke shaped `50,566` raw bytes to `24,025`
-bytes, saving `26,541` bytes (`52.49%`) with `7` saving rows.
+Current state: Phase 15 smoke records `NoShapingRecorded=false` and shows
+measurable savings for tool snapshots, usage reports, large TSAM tool results,
+and log-heavy probe/console results. The focused Phase 15 log smoke shaped
+`56,370` raw bytes to `39,650` bytes, saving `16,720` bytes (`29.66%`).
+`Unity.RunCommand` saved `11,433` bytes (`65.69%`) and `Unity.ReadConsole`
+saved `2,219` bytes (`77.00%`) in explicit `tool_result` rows.
 
 Use `Invoke-UnityMcpBatch` for repeated smoke/workflow calls that span packs.
 The Phase 14 batch smoke ran `9` ordered project/ui/scene/debug steps with `3`
@@ -173,6 +176,7 @@ Current TSAM-covered surfaces include:
 - Package compatibility and input-action asset inspection.
 - UI hierarchy/layout preview/apply tools and screen-layout verification.
 - Scene serialized-reference preview/apply binding.
+- Compact `Unity.RunCommand` log summaries and `Unity.ReadConsole` summary reads.
 - Usage reporting for payload, bridge, pack transition, tool snapshot, detail-ref, and TSAM stage coverage analysis.
 
 Broad legacy tools remain available where split coverage is incomplete.

--- a/docs/Telemetry
+++ b/docs/Telemetry
@@ -211,6 +211,56 @@ Smoke notes:
 - UI layout preview/apply remained small and unchanged rather than receiving artificial shaping.
 - Some lower-level `tool_execution` telemetry rows still show `rawBytes == shapedBytes` because they record the already-compacted tool response; the measured savings are now visible in explicit `tool_result` rows.
 
+## Phase 15 RunCommand And Console Compact Log Smoke Baseline
+
+A focused Phase 15 smoke test on 2026-04-26 passed the compact log-result
+targets:
+
+- Host project: `D:\2DUnityNewGame`.
+- Unity version: `6000.4.3f1`.
+- Metadata audit: pass with `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, and `debug=22`.
+- Scope: from fresh marker line `262`, `27` rows.
+- Payload rows: `6`; coverage rows: `21`.
+- Payload size: `56,370` raw bytes -> `39,650` shaped bytes.
+- Recorded savings: `16,720` bytes, `29.66%`.
+- `NoShapingRecorded=false`.
+- Connections: `2`.
+- Pack transitions: `3`.
+- Unmatched requests: `0`.
+- Failure rows: `0`.
+
+Top savings in the focused scope:
+
+- `tool_result:Unity.RunCommand`: `17,405` raw bytes -> `5,972` shaped bytes, saving `11,433` bytes (`65.69%`).
+- `tool_result:Unity.GetLensUsageReport`: `13,119` raw bytes -> `10,051` shaped bytes, saving `3,068` bytes (`23.39%`).
+- `tool_result:Unity.ReadConsole`: `2,882` raw bytes -> `663` shaped bytes, saving `2,219` bytes (`77.00%`).
+
+RunCommand smoke details:
+
+- The successful probe emitted `80` `result.Log(...)` execution lines and `40` `Debug.LogWarning(...)` console lines.
+- Inline execution log preview stayed at `1,421` characters with `executionLogsBytes=9,429`.
+- Inline result included structured `returnedData`.
+- `logSummary.execution` and `logSummary.console` included counts, first warning/error lines, truncation flags, and detail refs.
+- Direct `Unity.ReadDetailRef` resolved the execution-log detail payload (`9,429` bytes).
+
+Console smoke details:
+
+- `Unity.ReadConsole` in `Summary` format returned `entryCount=1`, `groupCount=1`, compact type counts, and one grouped row.
+- Direct `Unity.ReadDetailRef` resolved the full scanned console payload (`2,882` bytes).
+- The console summary used an existing large error row already present before the fresh marker; no expected-failure `RunCommand` call occurred in the happy-path scope.
+
+Expected-failure smoke details:
+
+- Compilation failure reported `failureStage=compilation` and `errorKind=compilation_failed`.
+- Execution log error reported `failureStage=execution` and `errorKind=execution_logged_errors`.
+- Unserializable `ReturnResult(...)` reported `failureStage=result_serialization`, `errorKind=result_serialization_failed`, and `exceptionType=Newtonsoft.Json.JsonException`.
+- All expected-failure responses kept compact log summaries and detail refs intact.
+
+Residual notes:
+
+- Small failure payloads can be larger after adding summary/detail metadata; this is expected and not counted as a saving row.
+- `Unity.ReadDetailRef` resolves correctly through direct MCP. The Phase 14 batch helper currently treats its unwrapped structured payload as a failed step in the batch summary, so detail-ref smoke reads used direct MCP.
+
 ---
 
 ## Current Findings
@@ -237,12 +287,13 @@ diagnostic sequence needs multiple packs.
 Phase 13 fixed the first measurable accounting gap for tool snapshots and usage
 reports. Phase 14 extended explicit `tool_result` shaping to large TSAM results:
 UI hierarchy preview/apply, scene binding preview/apply, UI verify, and Input
-System diagnostics now have compact inline data plus full detail refs.
+System diagnostics now have compact inline data plus full detail refs. Phase 15
+extended compact defaults to log-heavy `Unity.RunCommand` and `Unity.ReadConsole`
+summary results.
 
-Remaining shaping work should focus on log-heavy `Unity.RunCommand` and console
-results, any residual `Unity.ManageEditor` edge cases, and making telemetry
-presentation clearer when `tool_execution` rows record already-compacted
-responses.
+Remaining shaping work should focus on residual `Unity.ManageEditor` edge cases,
+batch-helper detail-ref normalization, and making telemetry presentation clearer
+when `tool_execution` rows record already-compacted responses.
 
 ### Diagnostic Surface Gaps
 

--- a/docs/unity-mcp-backlog.md
+++ b/docs/unity-mcp-backlog.md
@@ -20,6 +20,7 @@ latest dogfood findings.
 - TSAM tools must emit `normalization`, `service`, `adapter`, and `result_shaping` coverage rows.
 - The helper path now distinguishes direct MCP health from wrapper degradation, and `Invoke-UnityRunCommand` can bypass idle wait in healthy play mode.
 - Phase 14 payload telemetry records measurable compact-result savings for large TSAM results, and the batch helper reduces repeated smoke/session churn.
+- Phase 15 payload telemetry records measurable compact-log savings for `Unity.RunCommand` and `Unity.ReadConsole` summary results.
 
 ---
 
@@ -262,6 +263,49 @@ Smoke notes:
 
 ---
 
+## Latest Phase 15 RunCommand And Console Compact Log Smoke
+
+Date: 2026-04-26
+
+Result: passed compact-log happy path, with one helper follow-up.
+
+Host project:
+
+- `D:\2DUnityNewGame`
+- Unity `6000.4.3f1`
+
+Pack/export result:
+
+- Metadata audit: pass.
+- Export counts unchanged: `foundation=12`, `foundation+scene=32`, `foundation+ui=22`, `project=21`, `debug=22`.
+
+Telemetry result:
+
+- Focused happy-path scope: from fresh marker line `262`, `27` rows.
+- Payload rows: `6`; coverage rows: `21`.
+- Payload size: `56,370` raw bytes -> `39,650` shaped bytes.
+- Recorded savings: `16,720` bytes (`29.66%`).
+- `NoShapingRecorded=false`.
+- Connections: `2`.
+- Pack transitions: `3`.
+- Unmatched requests: `0`.
+- Failure rows: `0`.
+- Top savings:
+  - `Unity.RunCommand`: `17,405` raw bytes -> `5,972` shaped bytes, saving `11,433` bytes (`65.69%`).
+  - `Unity.ReadConsole`: `2,882` raw bytes -> `663` shaped bytes, saving `2,219` bytes (`77.00%`).
+  - `Unity.GetLensUsageReport`: `13,119` raw bytes -> `10,051` shaped bytes, saving `3,068` bytes (`23.39%`).
+
+Smoke notes:
+
+- Successful `Unity.RunCommand` emitted `80` execution log lines, `40` captured console warning lines, and inline structured `returnedData`.
+- Inline logs are short previews; `logSummary` carries counts, first warning/error lines, truncation flags, and detail refs.
+- `Unity.ReadConsole` summary returns counts and grouped rows inline while full scanned entries move behind `detailRef`.
+- Direct `Unity.ReadDetailRef` resolved both RunCommand and ReadConsole detail payloads.
+- Separate expected-failure smoke confirmed stable `failureStage`/`errorKind` values for compilation, execution, and result serialization.
+- Follow-up: the batch helper currently marks `Unity.ReadDetailRef` as failed because the detail tool returns an unwrapped structured payload; direct MCP detail reads are healthy.
+
+---
+
 ## P0
 
 ### Bridge And Helper Session Churn
@@ -289,13 +333,14 @@ Observed dogfood signals:
 - `Unity_ManageEditor` emitted payload rows above `220 KB`.
 - Tool snapshots contributed about `2.50 MB` raw payload across `29` rows.
 - Phase 14 compact-result smoke now reports `NoShapingRecorded=false` and `7` saving rows, including UI hierarchy, scene binding, UI verify, and Input System diagnostics.
+- Phase 15 compact-log smoke now reports `Unity.RunCommand` and `Unity.ReadConsole` `tool_result` savings.
 
 Work:
 
 - Keep `Unity.ManageEditor WaitForStableEditor` inline output compact.
 - Store full attempts and full editor state behind detail refs.
 - Reduce routine tool snapshot payload cost.
-- Compact log-heavy `Unity.RunCommand` and console outputs next.
+- Normalize batch-helper handling for `Unity.ReadDetailRef` responses.
 
 ---
 
@@ -342,9 +387,8 @@ Work:
 
 Work:
 
-- Make `Unity.RunCommand` failure stage and `errorKind` consistent across validation, compilation, execution, result serialization, transport/unknown, and unexpected exceptions.
-- Compact compilation, execution, and console logs by default.
-- Store full logs behind detail refs.
+- Keep `Unity.RunCommand` failure stage and `errorKind` consistent across validation, compilation, execution, result serialization, transport/unknown, and unexpected exceptions.
+- Keep compilation, execution, and console logs compact by default with full logs behind detail refs.
 - Add or improve structured recent-console reads so package/import errors do not require raw `Editor.log` grep.
 - Keep the play-mode helper bypass keyed to direct Lens health and compact editor state, even when `IsPlayingOrWillChangePlaymode` keeps the editor-stability label at `play_transition`.
 


### PR DESCRIPTION
…vements

- Introduced compact log summaries for `Unity.RunCommand` and `Unity.ReadConsole`, providing structured previews with detail references for full logs.
- Updated SKILL.md files for unity-dev-assistant, unity-mcp-bridge, and unity-mcp-lens-development to reflect new log handling practices and summary outputs.
- Improved CHANGELOG.md to document the addition of compact log summaries and related changes.
- Enhanced ReadConsole.cs and RunCommand.cs to support new log summary structures and detail references.
- Updated README-CODEX-PATCH.md and README.md to guide users on the new log handling features and best practices.
- Revised TSAM.md and Telemetry documentation to include Phase 15 results and focus on compact log outputs.
- Added backlog notes for Phase 15 compact-log savings and improvements in telemetry reporting.