### PR TITLE
Lens reliability and Roach dogfood sprint

### DIFF
--- a/.agents/plugins/lens-dev-plugin/.codex-plugin/plugin.json
+++ b/.agents/plugins/lens-dev-plugin/.codex-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "lens-dev-plugin",
-  "version": "0.1.5",
-  "description": "Unity MCP Lens development workflow bundle for Codex. Plugin v0.1.5, aligned with Lens host 0.1.0-alpha.12+.",
+  "version": "0.1.6",
+  "description": "Unity MCP Lens development workflow bundle for Codex. Plugin v0.1.6, aligned with Lens host 0.1.0-alpha.24+.",
   "author": {
     "name": "kanaw",
     "email": "",
@@ -19,9 +19,9 @@
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
-    "displayName": "Lens Dev Plugin v0.1.5",
-    "shortDescription": "v0.1.5 Unity MCP Lens workflows with fast health, safe stepping, recovery diagnostics, and bridge access.",
-    "longDescription": "Lens Dev Plugin v0.1.5 bundles Unity MCP Bridge, Unity Dev Assistant, Unity MCP Lens Development, and the local Lens MCP server config for Codex. This plugin version teaches Codex to use Unity.Editor.HealthCheckFast first, paused Unity.PlayMode.StepVerifier for play-mode smoke checks, diagnose-only Unity.Editor.RecoverFromHang, FallingSands GPU probes, and status-file hygiene from Lens host 0.1.0-alpha.12+.",
+    "displayName": "Lens Dev Plugin v0.1.6",
+    "shortDescription": "v0.1.6 Unity MCP Lens workflows with fast health, safe stepping, Main Menu pack selection, recovery diagnostics, and bridge access.",
+    "longDescription": "Lens Dev Plugin v0.1.6 bundles Unity MCP Bridge, Unity Dev Assistant, Unity MCP Lens Development, and the local Lens MCP server config for Codex. This plugin version teaches Codex to use Unity.Editor.HealthCheckFast first, paused Unity.PlayMode.StepVerifier for play-mode smoke checks, Unity.Workflow.SelectPackThroughMainMenu for FallingSands Main Menu pack selection, diagnose-only Unity.Editor.RecoverFromHang, FallingSands GPU probes, and status-file hygiene from Lens host 0.1.0-alpha.24+.",
     "developerName": "kanaw",
     "category": "Productivity",
     "capabilities": [

--- a/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "unity-dev-assistant"
-description: "Lens Dev Plugin v0.1.5. Use when Codex is working in a Unity project and needs the full Unity development workflow: fast HealthCheckFirst status checks, Lens bridge-authoritative editor access, explicit tool-pack selection, compile-idle gating, safe paused StepVerifier play-mode checks, runtime probes, FallingSands GPU probes, screenshot-assisted validation, or edit-mode versus play-mode ownership-drift diagnosis."
+description: "Lens Dev Plugin v0.1.6. Use when Codex is working in a Unity project and needs the full Unity development workflow: fast HealthCheckFirst status checks, Lens bridge-authoritative editor access, explicit tool-pack selection, compile-idle gating, safe paused StepVerifier play-mode checks, runtime probes, FallingSands Main Menu pack selection, FallingSands GPU probes, screenshot-assisted validation, or edit-mode versus play-mode ownership-drift diagnosis."
 ---
 
 # Unity Dev Assistant
@@ -9,8 +9,8 @@ Use this as the primary Unity workflow skill. It depends on [$unity-mcp-bridge](
 
 ## Version Marker
 
-- Plugin guidance version: `Lens Dev Plugin v0.1.5`
-- Expected installed Lens host: `0.1.0-alpha.12` or newer
+- Plugin guidance version: `Lens Dev Plugin v0.1.6`
+- Expected installed Lens host: `0.1.0-alpha.24` or newer
 - If Codex shows an older Lens Dev Plugin version, refresh the plugin cache from the repo-local source before trusting this skill's installed copy.
 
 Default assumption going forward:
@@ -24,6 +24,7 @@ Default assumption going forward:
 - First contact is `Unity.Editor.HealthCheckFast` when the tool is available. Continue only when `safeToContinue=true`; if `agent_should_stop=true`, stop editor-facing work and report the recommended next action.
 - Use `Unity.Bridge.ListConnections` for file-backed diagnostics. Stale malformed status files are warning context when fresh matching bridge/editor health exists; fresh relevant malformed status remains blocking.
 - Prefer `Unity.PlayMode.StepVerifier` for smoke checks that need Play Mode. Its default is paused stepping; do not allow free-running wall-clock simulation unless the user explicitly needs it.
+- Prefer `Unity.Workflow.SelectPackThroughMainMenu` when FallingSands pack selection must go through the real Main Menu UI. It clicks the pack button through runtime UI tools and verifies the active runtime pack without `Unity.RunCommand`.
 - Treat console deltas as the pass/fail surface: new errors fail, stale errors/warnings are context unless the task asks to clean them up.
 - Prefer `Unity.Editor.RecoverFromHang` with `diagnoseOnly=true` before any recovery action. Do not kill, restart, or clean scratch artifacts without explicit user permission.
 - Prefer `Unity.Workflow.RunGpuSimulationProbe` for FallingSands garden-style deterministic GPU checks instead of ad hoc `Unity.RunCommand`.
@@ -74,7 +75,7 @@ or YAML edits.
 - Preview backend changes: `Unity.ProjectSettings.PreviewActiveInputHandler`
 - Apply backend changes: `Unity.ProjectSettings.SetActiveInputHandler`
 - Use `Unity.RunCommand` only for project-specific probes not covered by Lens tools.
-- For play-mode UI state and interaction, prefer `Unity.UI.QueryRuntimeLayout` and `Unity.UI.InvokeControl` before project-specific `Unity.RunCommand` snippets.
+- For FallingSands Main Menu pack selection, prefer `Unity.Workflow.SelectPackThroughMainMenu`. For other play-mode UI state and interaction, prefer `Unity.UI.QueryRuntimeLayout` and `Unity.UI.InvokeControl` before project-specific `Unity.RunCommand` snippets.
 - Treat active input handler changes as editor-authored ProjectSettings mutations that may need script reload or editor restart before defines and devices settle.
 
 ## Authoring-First Tool Preference
@@ -226,7 +227,7 @@ Prefer a scene-owned debugger component when a project needs fast UI or state it
 - Platform-native helpers first
 - Mandatory first step for Unity work in a fresh chat: `scripts/Check-UnityDevSession.js` on macOS/Linux or `scripts/Check-UnityDevSession.ps1` on Windows
 - Preferred transport: `unity-mcp-lens`
-- Default Codex exported tool surface: `static_all` (`foundation+full`); raw host default remains `dynamic_packs`
+- Default Lens host tool surface: `static_all` (`foundation+full`); set `UNITY_MCP_LENS_TOOL_SURFACE_MODE=dynamic_packs` only for clients that explicitly need dynamic pack switching
 - Current `foundation` surface: `18` tools
 - Current `foundation` + `scene` surface: `50` tools
 - Current `foundation` + `ui` surface: `35` tools

--- a/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/references/authoring-drift.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/references/authoring-drift.md
@@ -41,7 +41,7 @@ result.Log("STATE::target={0};child={1};offset={2};size={3}",
     box != null ? box.size.ToString("F3") : "null");
 '@
 $script = Join-Path $PWD ".agents\plugins\lens-dev-plugin\skills\unity-dev-assistant\scripts\Invoke-UnityRunCommand.ps1"
-powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD" -Code $code
+& $script -ProjectPath "$PWD" -Code $code
 ```
 
 Run the read once in edit mode, then enter play mode and run the same read or

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: "unity-mcp-bridge"
-description: "Lens Dev Plugin v0.1.5. Use when Codex is working in a Unity project and needs fast file-backed Unity health, bridge diagnostics, safe stop contracts, or recovery diagnosis before touching Unity editor state. Prefer Unity.Editor.HealthCheckFast, the owned unity-mcp-lens stdio server, Command Center status, and explicit user escalation only when Unity or the bridge really needs intervention."
+description: "Lens Dev Plugin v0.1.6. Use when Codex is working in a Unity project and needs fast file-backed Unity health, bridge diagnostics, safe stop contracts, or recovery diagnosis before touching Unity editor state. Prefer Unity.Editor.HealthCheckFast, the owned unity-mcp-lens stdio server, Command Center status, and explicit user escalation only when Unity or the bridge really needs intervention."
 ---
 
 # Unity MCP Bridge
@@ -9,8 +9,8 @@ Use this skill as the operational guide for the local Unity MCP bridge and the o
 
 ## Version Marker
 
-- Plugin guidance version: `Lens Dev Plugin v0.1.5`
-- Expected installed Lens host: `0.1.0-alpha.12` or newer
+- Plugin guidance version: `Lens Dev Plugin v0.1.6`
+- Expected installed Lens host: `0.1.0-alpha.24` or newer
 - If Codex shows an older Lens Dev Plugin version, refresh the plugin cache from the repo-local source before trusting this skill's installed copy.
 
 ## Fast Health First
@@ -70,7 +70,7 @@ Start bridge-sensitive work with file-backed health before any Unity-backed call
 
 ```powershell
 $script = Join-Path $PWD ".agents\plugins\lens-dev-plugin\skills\unity-mcp-bridge\scripts\Check-UnityMcp.ps1"
-powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
+& $script -ProjectPath "$PWD"
 ```
 
 On macOS/Linux:
@@ -87,7 +87,7 @@ node .agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/Check-Unity
 
 ```powershell
 $script = Join-Path $PWD ".agents\plugins\lens-dev-plugin\skills\unity-mcp-bridge\scripts\Notify-UnityMcpActionRequired.ps1"
-powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
+& $script -ProjectPath "$PWD"
 ```
 
 12. Tell the user Unity MCP needs approval, reconnection, or editor recovery and pause Unity editor mutations until the bridge is healthy.
@@ -131,7 +131,7 @@ powershell -ExecutionPolicy Bypass -File $script -ProjectPath "$PWD"
 - When a tool result includes `detailRef`, use `Unity.ReadDetailRef` only when the preview/summary is insufficient. Do not immediately expand every large result.
 - `Unity.RunCommand`, `Unity.ReadConsole`, and `Unity.ManageEditor WaitForStableEditor` are expected to return compact, stage-aware results. Treat detail refs as the source for full logs, full scanned console entries, or full editor-state attempts when needed.
 - For known multi-step smoke or workflow sequences, prefer `Invoke-UnityMcpBatch` so one Lens session can activate the needed exact pack sets and avoid repeated schema/session churn.
-- On Windows, prefer `Invoke-UnityMcpBatch.ps1 -StepsPath <file>` for multi-line JSON. `-StepsJson` is accepted but shell quoting can strip JSON property quotes before Lens sees the payload.
+- On Windows, call helper scripts directly from PowerShell with `& script.ps1 ...`; avoid nesting `powershell -File` inside an existing PowerShell session. Prefer `Invoke-UnityMcpBatch.ps1 -StepsPath <file>` for multi-line JSON. `-StepsJson` is accepted but shell quoting can strip JSON property quotes before Lens sees the payload.
 
 ## Classification Rules
 

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/Invoke-UnityMcpBatch.js
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-bridge/scripts/Invoke-UnityMcpBatch.js
@@ -17,12 +17,12 @@ function loadSteps(args) {
 
 function parseStepsJson(rawJson, sourceLabel) {
   try {
-    return JSON.parse(rawJson);
+    return normalizeRawSteps(JSON.parse(rawJson));
   } catch (error) {
     const repairedJson = repairPowerShellStrippedJson(rawJson);
     if (repairedJson !== rawJson) {
       try {
-        return JSON.parse(repairedJson);
+        return normalizeRawSteps(JSON.parse(repairedJson));
       } catch (_repairError) {
       }
     }
@@ -36,6 +36,12 @@ function parseStepsJson(rawJson, sourceLabel) {
         `Input preview: ${preview}`
     );
   }
+}
+
+function normalizeRawSteps(value) {
+  if (Array.isArray(value)) return value;
+  if (value && typeof value === "object") return [value];
+  return value;
 }
 
 function repairPowerShellStrippedJson(rawJson) {
@@ -179,7 +185,7 @@ async function main() {
   const defaultTimeoutSeconds = common.getArgNumber(args, ["TimeoutSeconds"], 45);
   const rawSteps = loadSteps(args);
   if (!Array.isArray(rawSteps) || rawSteps.length === 0) {
-    throw new Error("Batch steps must be a non-empty JSON array.");
+    throw new Error("Batch steps must be a non-empty JSON array or a single step object.");
   }
 
   const steps = rawSteps.map((step, index) => normalizeStep(step, index, defaultTimeoutSeconds));
@@ -258,7 +264,16 @@ async function main() {
   process.exit(success ? 0 : 1);
 }
 
-main().catch((error) => {
-  console.error(error.message);
-  common.shutdownUnityMcpSessions().finally(() => process.exit(1));
-});
+if (require.main === module) {
+  main().catch((error) => {
+    console.error(error.message);
+    common.shutdownUnityMcpSessions().finally(() => process.exit(1));
+  });
+} else {
+  module.exports = {
+    loadSteps,
+    parseStepsJson,
+    normalizeRawSteps,
+    normalizeStep,
+  };
+}

--- a/.agents/plugins/lens-dev-plugin/skills/unity-mcp-lens-development/SKILL.md
+++ b/.agents/plugins/lens-dev-plugin/skills/unity-mcp-lens-development/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: unity-mcp-lens-development
-description: Lens Dev Plugin v0.1.5. Develop, test, and improve Unity MCP Lens tools, packs, bridge behavior, Command Center UI, safe health substrate, StepVerifier/recovery workflows, package UI, and Unity editor automation workflows. Use when working on Lens itself, adding or debugging Lens MCP tools, changing tool packs, validating bridge behavior, or making Unity editor-authored persistent changes for Lens projects.
+description: Lens Dev Plugin v0.1.6. Develop, test, and improve Unity MCP Lens tools, packs, bridge behavior, Command Center UI, safe health substrate, StepVerifier/recovery workflows, package UI, and Unity editor automation workflows. Use when working on Lens itself, adding or debugging Lens MCP tools, changing tool packs, validating bridge behavior, or making Unity editor-authored persistent changes for Lens projects.
 ---
 
 # Unity MCP Lens Development
@@ -17,8 +17,8 @@ Do not edit installed Codex cache copies or standalone `$CODEX_HOME/skills` copi
 
 ## Version Marker
 
-- Plugin guidance version: `Lens Dev Plugin v0.1.5`
-- Expected installed Lens host: `0.1.0-alpha.12` or newer
+- Plugin guidance version: `Lens Dev Plugin v0.1.6`
+- Expected installed Lens host: `0.1.0-alpha.24` or newer
 - The plugin version and display name must be visible in `.codex-plugin/plugin.json` so Codex's plugin view makes stale installs obvious.
 - Host version and plugin version are intentionally separate. Host builds advance host metadata; plugin versions advance only when Codex guidance, plugin metadata, or plugin scripts change.
 
@@ -29,6 +29,7 @@ Do not edit installed Codex cache copies or standalone `$CODEX_HOME/skills` copi
 - Session safety must block Unity-backed tools after watchdog/hung-command failures until a fresh non-busy editor and usable bridge are observed by `HealthCheckFast`.
 - `Unity.RunCommand` should use preflight/risk labels for risky snippets and a hard watchdog for execution.
 - `Unity.PlayMode.StepVerifier` is the default safe play-mode primitive. It should enter through the safe path, pause once runtime is observable, step exact counts, capture console deltas, and exit/restore state.
+- `Unity.Workflow.SelectPackThroughMainMenu` is the preferred FallingSands Main Menu pack-selection path. It should enter paused Play Mode, invoke the pack button through runtime UI tools, then verify the active runtime pack without `Unity.RunCommand` or direct pack selectors.
 - `Unity.Editor.RecoverFromHang` starts in `diagnoseOnly=true`; destructive options require explicit user args.
 - Status readers are non-destructive by default. Stale malformed files stay visible in diagnostics but must not poison a fresh matching bridge/editor-health pair.
 - Command Center is the Windows-first human UI for status, server refresh, settings, tool summaries, and explanations.
@@ -164,7 +165,7 @@ Phase 17 addresses the highest TintPaint dogfood pain without widening `foundati
 - Prefer `Unity.PlayMode.PointerInputSmoke` for pointer-path evidence in play mode; it reports observed Input System state, scroll state, UI/world hit evidence, and optional sampled gameplay state.
 - Prefer `Unity.Editor.ExitPlayMode` or `Exit-UnityPlayMode.ps1` for play-mode cleanup; avoid custom `Unity.RunCommand` stop snippets.
 - `Unity.GetLensUsageReport` compact output should summarize large pack-transition lists and report TSAM coverage summary data.
-- Prefer `Unity.UI.QueryRuntimeLayout` for runtime UI layout/state readback and `Unity.UI.InvokeControl` for play-mode button/slider/toggle actions before writing custom `Unity.RunCommand` snippets.
+- Prefer `Unity.Workflow.SelectPackThroughMainMenu` for FallingSands Main Menu pack selection. For other play-mode UI state and interaction, prefer `Unity.UI.QueryRuntimeLayout` and `Unity.UI.InvokeControl` before writing custom `Unity.RunCommand` snippets.
 - Prefer `Unity.UI.CaptureGameView` for Game view screenshots; its capture result should include readiness diagnostics, play/pause state, Game view size, camera/canvas counts, console delta, and fallback evidence when requested.
 
 ## Phase 8 Dogfood Hardening Truth
@@ -192,7 +193,7 @@ This batch addresses the BeeSurvivors Lens dogfood findings from 2026-05-07.
 
 - Prefer `Unity.Tools.Describe` for live tool schema and pack requirement discovery, especially when Codex dynamic indexing is stale.
 - Prefer `Unity.Tools.Menu` for compact pack-oriented navigation. In `UNITY_MCP_LENS_TOOL_SURFACE_MODE=static_all`, all enabled real tools are natively exposed up front and `Unity.SetToolPacks` is a compatibility no-op.
-- For Codex, prefer `static_all` as the reliability path; raw host binaries still default to `dynamic_packs` for clients that handle `tools/list_changed` correctly.
+- Lens host binaries now default to `static_all` as the reliability path; set `UNITY_MCP_LENS_TOOL_SURFACE_MODE=dynamic_packs` only for clients that handle `tools/list_changed` correctly and explicitly want dynamic packs.
 - `Unity.Tools.Describe` or `Unity.Tools.ActivateAndVerify` proving a tool exists does not prove the current Codex thread has indexed it as callable. If a described active-pack tool is not callable after `Unity.SetToolPacks`, classify the issue as client dynamic-indexing drift and use helper scripts or `Invoke-UnityMcpBatch` while preserving the raw host evidence.
 - `Unity.SetToolPacks` should report whether `notifications/tools/list_changed` was emitted. If Codex still cannot call the described tool after that notification, do not keep widening packs; collect the active packs, manifest/profile version, and missing callable tool name.
 - Prefer `Unity.Editor.SyncScripts` via `Sync-UnityScriptChanges` for deterministic script refresh/compile waits; model-facing calls should wait through scheduled refresh/reload windows and return `readyForFollowUp=true` only when follow-up Unity actions are safe. No changed paths plus no force must return quickly.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **unity-mcp-lens** (12366 symbols, 28099 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **unity-mcp-lens** (12661 symbols, 28701 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,7 @@
 <!-- gitnexus:start -->
 # GitNexus — Code Intelligence
 
-This project is indexed by GitNexus as **unity-mcp-lens** (12366 symbols, 28099 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
+This project is indexed by GitNexus as **unity-mcp-lens** (12661 symbols, 28701 relationships, 300 execution flows). Use the GitNexus MCP tools to understand code, assess impact, and navigate safely.
 
 > If any GitNexus tool warns the index is stale, run `npx gitnexus analyze` in terminal first.
 

--- a/Editor/Lens/Adapters/Unity/Assets/UnityAssetSpriteSheetBindingAdapter.cs
+++ b/Editor/Lens/Adapters/Unity/Assets/UnityAssetSpriteSheetBindingAdapter.cs
@@ -91,6 +91,14 @@ namespace Becool.UnityMcpLens.Editor.Adapters.Unity.Assets
                 return false;
             }
 
+#pragma warning disable CS0618
+            SpriteMetaData[] existingImporterMetadata = importer.spritesheet ?? Array.Empty<SpriteMetaData>();
+#pragma warning restore CS0618
+            plannedMetadata = PreserveExistingSpriteNamesForMatchingSlices(
+                plannedMetadata,
+                existingImporterMetadata,
+                out int preservedExistingSpriteNameCount);
+
             Object targetAsset = AssetDatabase.LoadMainAssetAtPath(targetAssetPath);
             if (targetAsset == null)
             {
@@ -214,6 +222,7 @@ namespace Becool.UnityMcpLens.Editor.Adapters.Unity.Assets
                 requestedFrameCount = request.FrameCount,
                 importedSpriteCount = previewOnly ? plannedMetadata.Length : readbackSprites.Length,
                 spriteNames,
+                preservedExistingSpriteNameCount,
                 targetFieldReadbackCount = readbackReferences.Length,
                 targetAssetDirty = EditorUtility.IsDirty(targetAsset),
                 saved = !previewOnly && (importerApplied || bindingApplied),
@@ -412,6 +421,44 @@ namespace Becool.UnityMcpLens.Editor.Adapters.Unity.Assets
                 return true;
 
             return !SpriteSheetsEqual(importer, plannedMetadata);
+        }
+
+        static SpriteMetaData[] PreserveExistingSpriteNamesForMatchingSlices(
+            SpriteMetaData[] plannedMetadata,
+            SpriteMetaData[] existingMetadata,
+            out int preservedNameCount)
+        {
+            preservedNameCount = 0;
+            plannedMetadata ??= Array.Empty<SpriteMetaData>();
+            existingMetadata ??= Array.Empty<SpriteMetaData>();
+
+            if (plannedMetadata.Length == 0 || plannedMetadata.Length != existingMetadata.Length)
+                return plannedMetadata;
+
+            var existingNames = new HashSet<string>(StringComparer.Ordinal);
+            var adjustedMetadata = new SpriteMetaData[plannedMetadata.Length];
+            for (int i = 0; i < plannedMetadata.Length; i++)
+            {
+                SpriteMetaData planned = plannedMetadata[i];
+                SpriteMetaData existing = existingMetadata[i];
+                if (!Approximately(existing.rect, planned.rect) ||
+                    !Approximately(existing.pivot, planned.pivot) ||
+                    existing.alignment != planned.alignment ||
+                    string.IsNullOrWhiteSpace(existing.name) ||
+                    !existingNames.Add(existing.name))
+                {
+                    preservedNameCount = 0;
+                    return plannedMetadata;
+                }
+
+                if (!string.Equals(existing.name, planned.name, StringComparison.Ordinal))
+                    preservedNameCount++;
+
+                planned.name = existing.name;
+                adjustedMetadata[i] = planned;
+            }
+
+            return preservedNameCount > 0 ? adjustedMetadata : plannedMetadata;
         }
 
         static void ApplyImporterSettings(TextureImporter importer, SpriteMetaData[] plannedMetadata, AssetSpriteSheetAndBindRequest request, ParsedTextureSettings settings)

--- a/Editor/Lens/Tools/EditorScriptSyncTools.cs
+++ b/Editor/Lens/Tools/EditorScriptSyncTools.cs
@@ -13,6 +13,7 @@ using Becool.UnityMcpLens.Editor.Utils;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityEditor;
+using UnityEditor.PackageManager;
 
 namespace Becool.UnityMcpLens.Editor.Tools
 {
@@ -35,6 +36,12 @@ namespace Becool.UnityMcpLens.Editor.Tools
 
         [McpDescription("Consecutive stable polls required before reporting editor idle.", Required = false, Default = 2)]
         public int StablePollCount { get; set; } = 2;
+
+        [McpDescription("Request a Unity Package Manager resolve before refreshing package paths when package-affecting changes are supplied.", Required = false, Default = true)]
+        public bool ResolvePackages { get; set; } = true;
+
+        [McpDescription("Host-side hint that stale local file-package sources were detected and package asset paths were injected into changedPaths.", Required = false, Default = false)]
+        public bool LocalPackageRefreshRequested { get; set; } = false;
     }
 
     [McpTool(ToolPackCatalog.EditorSyncScriptsToolName,
@@ -135,6 +142,10 @@ namespace Becool.UnityMcpLens.Editor.Tools
             bool refreshScheduledAfterResponse = false;
             ConsoleCursorSnapshot consoleBefore = ConsoleCursorDelta.Capture();
             int initialConsoleErrorCount = consoleBefore.ErrorCount;
+            bool packageResolveRequested = ShouldResolvePackages(relevantChangedPaths, parameters.Force, parameters.ResolvePackages, parameters.LocalPackageRefreshRequested);
+            var packageResolvePaths = relevantChangedPaths
+                .Where(IsPackageManagerAffectingPath)
+                .ToArray();
 
             if (BuildPipeline.isBuildingPlayer)
                 return BuildRefusedResult("Unity is building a player; script sync was refused.", "building_player");
@@ -161,6 +172,8 @@ namespace Becool.UnityMcpLens.Editor.Tools
                     noChangesDetected = true,
                     changedPaths,
                     relevantChangedPaths,
+                    packageResolveRequested,
+                    packageResolvePaths,
                     refreshRequested = false,
                     refreshScheduledAfterResponse = false,
                     compileStarted = false,
@@ -184,7 +197,7 @@ namespace Becool.UnityMcpLens.Editor.Tools
 
             if (!alreadyBusy)
             {
-                ScheduleRefreshAfterResponse(relevantChangedPaths, parameters.Force, parameters.TimeoutSeconds);
+                ScheduleRefreshAfterResponse(relevantChangedPaths, parameters.Force, parameters.TimeoutSeconds, packageResolveRequested);
                 refreshRequested = true;
                 refreshScheduledAfterResponse = true;
                 editorIdle = false;
@@ -263,6 +276,8 @@ namespace Becool.UnityMcpLens.Editor.Tools
                 noChangesDetected,
                 changedPaths,
                 relevantChangedPaths,
+                packageResolveRequested,
+                packageResolvePaths,
                 force = parameters.Force,
                 waitForCompile = parameters.WaitForCompile,
                 refreshRequested,
@@ -356,6 +371,8 @@ namespace Becool.UnityMcpLens.Editor.Tools
                     noChangesDetected,
                     changedPaths,
                     relevantChangedPaths,
+                    packageResolveRequested,
+                    packageResolvePaths,
                     refreshRequested = false,
                     refreshScheduledAfterResponse = false,
                     compileStarted,
@@ -477,14 +494,14 @@ namespace Becool.UnityMcpLens.Editor.Tools
             }
         }
 
-        static void ScheduleRefreshAfterResponse(string[] relevantChangedPaths, bool force, int timeoutSeconds)
+        static void ScheduleRefreshAfterResponse(string[] relevantChangedPaths, bool force, int timeoutSeconds, bool packageResolveRequested)
         {
-            EditorApplication.delayCall += () =>
+            EditorApplication.delayCall += async () =>
             {
                 try
                 {
                     BridgeStatusTracker.MarkEditorReloading("sync_scripts", Math.Max(5.0, timeoutSeconds));
-                    RequestRefresh(relevantChangedPaths, force);
+                    await RequestRefreshAsync(relevantChangedPaths, force, packageResolveRequested);
                 }
                 catch (Exception ex)
                 {
@@ -493,12 +510,16 @@ namespace Becool.UnityMcpLens.Editor.Tools
             };
         }
 
-        static void RequestRefresh(string[] relevantChangedPaths, bool force)
+        static async Task RequestRefreshAsync(string[] relevantChangedPaths, bool force, bool packageResolveRequested)
         {
+            if (packageResolveRequested)
+                await RequestPackageResolveAsync();
+
             bool globalRefresh = force || relevantChangedPaths.Length == 0;
             foreach (string path in relevantChangedPaths)
             {
-                if (path.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase))
+                if (path.StartsWith("Assets/", StringComparison.OrdinalIgnoreCase) ||
+                    path.StartsWith("Packages/", StringComparison.OrdinalIgnoreCase))
                     AssetDatabase.ImportAsset(path, ImportAssetOptions.ForceUpdate | ImportAssetOptions.ForceSynchronousImport);
                 else
                     globalRefresh = true;
@@ -508,6 +529,40 @@ namespace Becool.UnityMcpLens.Editor.Tools
                 AssetDatabase.Refresh(ImportAssetOptions.ForceSynchronousImport);
 
             UnityEditor.Compilation.CompilationPipeline.RequestScriptCompilation();
+        }
+
+        static async Task RequestPackageResolveAsync()
+        {
+            try
+            {
+                Client.Resolve();
+                await Task.Delay(500);
+            }
+            catch (Exception ex)
+            {
+                McpLog.Warning($"Unity.Editor.SyncScripts failed to request package resolve: {ex.Message}");
+            }
+        }
+
+        static bool ShouldResolvePackages(string[] relevantChangedPaths, bool force, bool resolvePackages, bool localPackageRefreshRequested)
+        {
+            if (!resolvePackages)
+                return false;
+
+            return localPackageRefreshRequested ||
+                relevantChangedPaths.Any(IsPackageManagerAffectingPath) ||
+                (force && relevantChangedPaths.Any(path => path.StartsWith("Packages/", StringComparison.OrdinalIgnoreCase)));
+        }
+
+        static bool IsPackageManagerAffectingPath(string path)
+        {
+            if (string.IsNullOrWhiteSpace(path))
+                return false;
+
+            string normalized = path.Replace('\\', '/').Trim();
+            return normalized.Equals("Packages/manifest.json", StringComparison.OrdinalIgnoreCase) ||
+                normalized.Equals("Packages/packages-lock.json", StringComparison.OrdinalIgnoreCase) ||
+                normalized.StartsWith("Packages/", StringComparison.OrdinalIgnoreCase);
         }
 
         static string NormalizeUnityRelativePath(string path)

--- a/Editor/Lens/Tools/FallingSandsWorkflowTools.cs
+++ b/Editor/Lens/Tools/FallingSandsWorkflowTools.cs
@@ -230,20 +230,23 @@ namespace Becool.UnityMcpLens.Editor.Tools
             }
         }
 
-        [McpTool(PackVerifyToolName, "Selects a FallingSands element pack and verifies the active runtime pack after optional scene load.", "Verify Runtime Pack Selection", Groups = new[] { "runtime", "diagnostics" }, EnabledByDefault = true)]
+        [McpTool(PackVerifyToolName, "Optionally selects a FallingSands element pack and verifies the active runtime pack after optional scene load.", "Verify Runtime Pack Selection", Groups = new[] { "runtime", "diagnostics" }, EnabledByDefault = true)]
         public static object VerifyRuntimePackSelection(JObject parameters)
         {
             parameters ??= new JObject();
             string selectedPackId = GetString(parameters, "garden", "selectedPackId", "SelectedPackId", "packId", "PackId");
             string scenePath = GetString(parameters, null, "scenePath", "ScenePath");
             bool requirePlayMode = GetBool(parameters, true, "requirePlayMode", "RequirePlayMode");
+            bool selectPack = GetBool(parameters, true, "selectPack", "SelectPack");
             string workflowId = "pack-handoff-" + Guid.NewGuid().ToString("N");
             object before = LensTransactionSnapshot.Capture(workflowId);
             object sceneLoad = null;
 
             try
             {
-                SelectFallingSandsPack(selectedPackId);
+                if (selectPack)
+                    SelectFallingSandsPack(selectedPackId);
+
                 if (!string.IsNullOrWhiteSpace(scenePath) && !EditorApplication.isPlaying)
                 {
                     string normalizedScenePath = NormalizeScenePath(scenePath);
@@ -289,6 +292,7 @@ namespace Becool.UnityMcpLens.Editor.Tools
                 {
                     workflowId,
                     selectedPackId,
+                    selectPack,
                     activeRuntimePackName = activePackName,
                     elementCount,
                     sceneLoaded = sceneLoad,
@@ -305,6 +309,7 @@ namespace Becool.UnityMcpLens.Editor.Tools
                 {
                     workflowId,
                     selectedPackId,
+                    selectPack,
                     scenePath,
                     sceneLoad,
                     passed = false,

--- a/Editor/Lens/Tools/PlayModeStepVerifierTools.cs
+++ b/Editor/Lens/Tools/PlayModeStepVerifierTools.cs
@@ -181,8 +181,8 @@ This tool does not free-run real-time simulation by default. The Lens host shoul
                     rawData.reason,
                     rawData.consoleDelta,
                     rawData.cleanup,
-                    before,
-                    after
+                    before = SummarizeSnapshot(before),
+                    after = SummarizeSnapshot(after)
                 };
 
                 object shaped = ToolResultCompactor.ShapeStructuredPayload(
@@ -299,6 +299,45 @@ This tool does not free-run real-time simulation by default. The Lens host shoul
                 after.UnscaledTime > before.UnscaledTime ||
                 after.RuntimeTime > before.RuntimeTime ||
                 after.FixedTime > before.FixedTime;
+        }
+
+        static object SummarizeSnapshot(object snapshot)
+        {
+            try
+            {
+                JObject root = JObject.FromObject(snapshot ?? new { });
+                JToken dirtyAssets = root["dirtyAssets"];
+                JToken dirtyScenes = root["dirtyScenes"];
+                return new
+                {
+                    workflowId = root["workflowId"],
+                    capturedUtc = root["capturedUtc"],
+                    playMode = root["playMode"],
+                    activeScene = root["activeScene"],
+                    compileImportState = root["compileImportState"],
+                    dirtyScenes = new
+                    {
+                        available = dirtyScenes?["available"],
+                        dirtySceneCount = dirtyScenes?["dirtySceneCount"] ?? dirtyScenes?["sceneCount"],
+                        truncated = dirtyScenes?["truncated"]
+                    },
+                    dirtyAssets = new
+                    {
+                        available = dirtyAssets?["available"],
+                        dirtyAssetCount = dirtyAssets?["dirtyAssetCount"],
+                        truncated = dirtyAssets?["truncated"]
+                    },
+                    consoleCursor = root["consoleCursor"],
+                    activeToolPacks = root["activeToolPacks"],
+                    selectedBridgeSessionId = root["selectedBridgeSessionId"],
+                    selectedConnectionId = root["selectedConnectionId"],
+                    manifestVersion = root["manifestVersion"]
+                };
+            }
+            catch
+            {
+                return new { available = false };
+            }
         }
 
         static int GetConsoleDeltaInt(object consoleDelta, string name)

--- a/Editor/Lens/Tools/RuntimeInvokeComponentMethodTools.cs
+++ b/Editor/Lens/Tools/RuntimeInvokeComponentMethodTools.cs
@@ -1,9 +1,11 @@
 #nullable disable
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Becool.UnityMcpLens.Editor.Adapters.Unity;
 using Becool.UnityMcpLens.Editor.Helpers;
@@ -22,6 +24,8 @@ namespace Becool.UnityMcpLens.Editor.Tools
     public static class RuntimeInvokeComponentMethodTools
     {
         const string ToolName = "Unity.Runtime.InvokeComponentMethod";
+        const int MaxReturnedDataDepth = 4;
+        const int MaxReturnedDataItems = 64;
 
         [McpSchema(ToolName)]
         public static object GetSchema()
@@ -218,6 +222,7 @@ namespace Becool.UnityMcpLens.Editor.Tools
             object beforeFrameCounts = EditorToolStateHelpers.BuildRuntimeProbeData();
             object beforeState = ComponentSummarySerializer.GetSafeComponentData(component, includeNonPublicSerializedFields: true);
             object returnValue = method.Invoke(component, convertedArgs);
+            ReturnedDataShape returnedData = BuildReturnedData(returnValue);
 
             if (waitFrames > 0)
                 await Task.Delay(Math.Max(1, waitFrames) * 16);
@@ -267,6 +272,11 @@ namespace Becool.UnityMcpLens.Editor.Tools
                 },
                 args = args.ToArray(),
                 returnValue = DescribeValue(returnValue),
+                returnedData = returnedData.InlineData,
+                returnedDataIncluded = returnedData.IncludedInline,
+                returnedDataBytes = returnedData.Bytes,
+                returnedDataDetailRef = returnedData.DetailRef,
+                returnedDataTruncated = returnedData.Truncated,
                 waitFrames,
                 frameCounts = new
                 {
@@ -299,6 +309,11 @@ namespace Becool.UnityMcpLens.Editor.Tools
                 component = root["component"],
                 method = root["method"],
                 returnValue = root["returnValue"],
+                returnedData = root["returnedData"],
+                returnedDataIncluded = root["returnedDataIncluded"],
+                returnedDataBytes = root["returnedDataBytes"],
+                returnedDataDetailRef = root["returnedDataDetailRef"],
+                returnedDataTruncated = root["returnedDataTruncated"],
                 waitFrames = root["waitFrames"],
                 frameCounts = root["frameCounts"],
                 stateChanged = root["stateChanged"],
@@ -596,6 +611,184 @@ namespace Becool.UnityMcpLens.Editor.Tools
             }
 
             return value.ToString();
+        }
+
+        sealed class ReturnedDataShape
+        {
+            public object InlineData;
+            public bool IncludedInline;
+            public int Bytes;
+            public object DetailRef;
+            public bool Truncated;
+        }
+
+        static ReturnedDataShape BuildReturnedData(object value)
+        {
+            bool truncated = false;
+            object shaped = ShapeReturnedValue(value, 0, new HashSet<int>(), ref truncated);
+            string serialized = JsonConvert.SerializeObject(shaped, Formatting.None);
+            int bytes = PayloadBudgeting.GetUtf8ByteCount(serialized);
+            object detailRef = bytes > PayloadBudgetPolicy.MaxToolResultBytes
+                ? ToolResultCompactor.CreateStoredDetailRef(
+                    ToolName,
+                    shaped,
+                    bytes,
+                    new { kind = "runtime_invoke_component_method_returned_data" })
+                : null;
+            bool includeInline = bytes <= PayloadBudgetPolicy.MaxToolResultBytes || detailRef == null;
+
+            return new ReturnedDataShape
+            {
+                InlineData = includeInline ? shaped : null,
+                IncludedInline = includeInline,
+                Bytes = bytes,
+                DetailRef = detailRef,
+                Truncated = truncated
+            };
+        }
+
+        static object ShapeReturnedValue(object value, int depth, HashSet<int> visited, ref bool truncated)
+        {
+            if (value == null)
+                return null;
+
+            Type type = value.GetType();
+            Type nullableType = Nullable.GetUnderlyingType(type) ?? type;
+            if (value is string || nullableType.IsPrimitive || nullableType.IsEnum || value is decimal)
+                return value;
+            if (value is DateTime dateTime)
+                return dateTime.ToString("O");
+            if (value is DateTimeOffset dateTimeOffset)
+                return dateTimeOffset.ToString("O");
+            if (value is Guid guid)
+                return guid.ToString("D");
+            if (value is Vector2 vector2)
+                return new { x = vector2.x, y = vector2.y };
+            if (value is Vector3 vector3)
+                return new { x = vector3.x, y = vector3.y, z = vector3.z };
+            if (value is Color color)
+                return new { r = color.r, g = color.g, b = color.b, a = color.a };
+            if (value is Object unityObject)
+            {
+                return new
+                {
+                    name = unityObject.name,
+                    type = unityObject.GetType().FullName,
+                    objectId = UnityApiAdapter.GetObjectIdOrZero(unityObject)
+                };
+            }
+
+            if (depth >= MaxReturnedDataDepth)
+            {
+                truncated = true;
+                return new { type = type.FullName, truncated = true };
+            }
+
+            if (!type.IsValueType)
+            {
+                int identity = RuntimeHelpers.GetHashCode(value);
+                if (!visited.Add(identity))
+                {
+                    truncated = true;
+                    return new { type = type.FullName, circularReference = true };
+                }
+            }
+
+            if (value is IDictionary dictionary)
+            {
+                var shaped = new Dictionary<string, object>();
+                int count = 0;
+                foreach (DictionaryEntry entry in dictionary)
+                {
+                    if (count >= MaxReturnedDataItems)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    string key = entry.Key?.ToString() ?? string.Empty;
+                    shaped[key] = ShapeReturnedValue(entry.Value, depth + 1, visited, ref truncated);
+                    count++;
+                }
+
+                return shaped;
+            }
+
+            if (value is IEnumerable enumerable)
+            {
+                var shaped = new List<object>();
+                int count = 0;
+                foreach (object item in enumerable)
+                {
+                    if (count >= MaxReturnedDataItems)
+                    {
+                        truncated = true;
+                        break;
+                    }
+
+                    shaped.Add(ShapeReturnedValue(item, depth + 1, visited, ref truncated));
+                    count++;
+                }
+
+                return shaped.ToArray();
+            }
+
+            return ShapeReturnedObject(value, type, depth, visited, ref truncated);
+        }
+
+        static object ShapeReturnedObject(object value, Type type, int depth, HashSet<int> visited, ref bool truncated)
+        {
+            var shaped = new Dictionary<string, object>
+            {
+                ["type"] = type.FullName
+            };
+
+            int count = 0;
+            foreach (PropertyInfo property in type.GetProperties(BindingFlags.Public | BindingFlags.Instance)
+                .Where(property => property.CanRead && property.GetIndexParameters().Length == 0)
+                .OrderBy(property => property.Name, StringComparer.Ordinal))
+            {
+                if (count >= MaxReturnedDataItems)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                try
+                {
+                    shaped[property.Name] = ShapeReturnedValue(property.GetValue(value), depth + 1, visited, ref truncated);
+                    count++;
+                }
+                catch
+                {
+                    shaped[property.Name] = new { unavailable = true };
+                }
+            }
+
+            foreach (FieldInfo field in type.GetFields(BindingFlags.Public | BindingFlags.Instance)
+                .OrderBy(field => field.Name, StringComparer.Ordinal))
+            {
+                if (count >= MaxReturnedDataItems)
+                {
+                    truncated = true;
+                    break;
+                }
+
+                try
+                {
+                    shaped[field.Name] = ShapeReturnedValue(field.GetValue(value), depth + 1, visited, ref truncated);
+                    count++;
+                }
+                catch
+                {
+                    shaped[field.Name] = new { unavailable = true };
+                }
+            }
+
+            if (count == 0)
+                shaped["stringValue"] = value.ToString();
+
+            return shaped;
         }
 
         static bool HasAllowedMethodMarker(MethodInfo method, string[] allowedMethodMarkers)

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ C:\Users\<you>\.unity\unity-mcp-lens\unity_mcp_lens_win.exe
 5. Verify:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Check-UnityDevSession.ps1 -ProjectPath C:\Path\To\UnityProject
+& .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Check-UnityDevSession.ps1 -ProjectPath C:\Path\To\UnityProject
 ```
 
 ---
@@ -111,7 +111,7 @@ For repeated smoke or workflow checks, use the repo-local batch helper so
 multiple project/ui/scene/debug calls share one Lens session:
 
 ```powershell
-powershell -ExecutionPolicy Bypass -File .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Invoke-UnityMcpBatch.ps1 -ProjectPath C:\Path\To\UnityProject -StepsPath C:\Path\To\steps.json
+& .agents/plugins/lens-dev-plugin/skills/unity-dev-assistant/scripts/Invoke-UnityMcpBatch.ps1 -ProjectPath C:\Path\To\UnityProject -StepsPath C:\Path\To\steps.json
 ```
 
 ---

--- a/Tools~/Test-InvokeUnityMcpBatchParsing.js
+++ b/Tools~/Test-InvokeUnityMcpBatchParsing.js
@@ -1,0 +1,44 @@
+const assert = require("assert");
+const path = require("path");
+
+const batch = require(path.resolve(
+  __dirname,
+  "..",
+  ".agents",
+  "plugins",
+  "lens-dev-plugin",
+  "skills",
+  "unity-mcp-bridge",
+  "scripts",
+  "Invoke-UnityMcpBatch.js"));
+
+const single = batch.parseStepsJson(JSON.stringify({
+  name: "health",
+  tool: "Unity.Editor.HealthCheckFast",
+  arguments: { includeCandidates: true },
+}), "single-object-test");
+
+assert(Array.isArray(single), "single object should be wrapped into an array");
+assert.strictEqual(single.length, 1, "single object should produce one step");
+assert.strictEqual(single[0].tool, "Unity.Editor.HealthCheckFast");
+assert.strictEqual(single[0].arguments.includeCandidates, true);
+
+const many = batch.parseStepsJson(JSON.stringify([
+  { tool: "Unity.Editor.HealthCheckFast" },
+  { tool: "Unity.Bridge.ListConnections" },
+]), "array-test");
+
+assert(Array.isArray(many), "array input should remain an array");
+assert.strictEqual(many.length, 2, "array input should preserve all steps");
+
+const normalized = batch.normalizeStep(single[0], 0, 45);
+assert.strictEqual(normalized.name, "health");
+assert.strictEqual(normalized.tool, "Unity.Editor.HealthCheckFast");
+assert.strictEqual(normalized.timeoutSeconds, 45);
+
+assert.throws(
+  () => batch.normalizeStep({}, 0, 45),
+  /requires a string 'tool'/,
+  "invalid step should still be rejected");
+
+console.log("Invoke-UnityMcpBatch parsing tests passed.");

--- a/Tools~/Test-McpDynamicToolExposure.js
+++ b/Tools~/Test-McpDynamicToolExposure.js
@@ -22,6 +22,7 @@ const requiredBootstrapWorkflowTools = [
   "Unity_Editor_RecoverFromHang",
   "Unity_Workflow_RunGpuSimulationProbe",
   "Unity_Workflow_VerifyRuntimePackSelection",
+  "Unity_Workflow_SelectPackThroughMainMenu",
 ];
 
 const foundationToolNames = [
@@ -125,14 +126,21 @@ class McpHostClient {
     this.notifications = [];
     this.notificationWaiters = [];
     this.stderr = "";
+    const env = {
+      ...process.env,
+      UNITY_MCP_STATUS_DIR: statusDir,
+      UNITY_MCP_PROJECT_PATH: projectRoot,
+    };
+    const toolSurfaceMode = options.toolSurfaceMode ?? process.env.UNITY_MCP_LENS_TOOL_SURFACE_MODE;
+    if (toolSurfaceMode) {
+      env.UNITY_MCP_LENS_TOOL_SURFACE_MODE = toolSurfaceMode;
+    } else {
+      delete env.UNITY_MCP_LENS_TOOL_SURFACE_MODE;
+    }
+
     this.child = childProcess.spawn(hostPath, [], {
       cwd: projectRoot,
-      env: {
-        ...process.env,
-        UNITY_MCP_STATUS_DIR: statusDir,
-        UNITY_MCP_PROJECT_PATH: projectRoot,
-        UNITY_MCP_LENS_TOOL_SURFACE_MODE: options.toolSurfaceMode || process.env.UNITY_MCP_LENS_TOOL_SURFACE_MODE || "dynamic_packs",
-      },
+      env,
       stdio: ["pipe", "pipe", "pipe"],
       windowsHide: true,
     });
@@ -791,6 +799,7 @@ async function runDynamicPacksScenario() {
     assertReadOnlyHint(foundationList.tools, "Unity_Editor_RecoverFromHang", false);
     assertReadOnlyHint(foundationList.tools, "Unity_Workflow_RunGpuSimulationProbe", false);
     assertReadOnlyHint(foundationList.tools, "Unity_Workflow_VerifyRuntimePackSelection", false);
+    assertReadOnlyHint(foundationList.tools, "Unity_Workflow_SelectPackThroughMainMenu", false);
     for (const assetToolName of requiredAssetTools) {
       assert(!foundationNames.includes(assetToolName), `foundation tools/list should not expose ${assetToolName}`);
     }
@@ -843,6 +852,7 @@ async function runStaticAllScenario() {
     assertReadOnlyHint(staticList.tools, "Unity_Editor_RecoverFromHang", false);
     assertReadOnlyHint(staticList.tools, "Unity_Workflow_RunGpuSimulationProbe", false);
     assertReadOnlyHint(staticList.tools, "Unity_Workflow_VerifyRuntimePackSelection", false);
+    assertReadOnlyHint(staticList.tools, "Unity_Workflow_SelectPackThroughMainMenu", false);
 
     const projectResult = await client.callTool("Unity_Project_PackageCompatibility", {});
     assert.strictEqual(projectResult.structuredContent.success, true, "pack-gated project tool should succeed in static_all without pack switching");
@@ -881,6 +891,31 @@ async function runStaticAllScenario() {
   }
 }
 
+async function runDefaultStaticAllScenario() {
+  const context = new ScenarioContext();
+  let client = null;
+  try {
+    await context.startBridge();
+    client = new McpHostClient(context.projectRoot, context.statusDir);
+    await client.initialize();
+
+    const list = await client.listTools();
+    const names = list.tools.map((tool) => tool.name);
+    assertNamesInclude(names, [
+      "Unity_Project_PackageCompatibility",
+      "Unity_Asset_Search",
+      "Unity_UI_VerifyScreenLayout",
+    ], "default startup tools/list should be static_all");
+
+    const menuResultPayload = await client.callTool("Unity_Tools_Menu", {});
+    assert.strictEqual(menuResultPayload.structuredContent.success, true, "Unity_Tools_Menu should succeed in default mode");
+    assert.strictEqual(menuResultPayload.structuredContent.data.toolSurfaceMode, "static_all");
+  } finally {
+    if (client) await client.dispose().catch(() => {});
+    await context.dispose();
+  }
+}
+
 async function main() {
   assert(fs.existsSync(hostPath), `Host path does not exist: ${hostPath}`);
   const pluginConfig = JSON.parse(fs.readFileSync(path.join(repoRoot, ".agents", "plugins", "lens-dev-plugin", ".mcp.json"), "utf8"));
@@ -890,6 +925,7 @@ async function main() {
     "Codex plugin config should default Lens to static_all",
   );
 
+  await runDefaultStaticAllScenario();
   await runDynamicPacksScenario();
   await runStaticAllScenario();
 

--- a/Tools~/Test-McpHostTransportRecovery.js
+++ b/Tools~/Test-McpHostTransportRecovery.js
@@ -157,6 +157,7 @@ class FakeBridge {
       healthHeartbeat: this.options.healthHeartbeat,
       toolCount: 3,
       writeHealth: this.options.writeHealth,
+      healthFlags: this.options.healthFlags,
     });
   }
 
@@ -227,6 +228,7 @@ class ScenarioContext {
     this.failed = false;
     this.bridge = null;
     this.bridges = [];
+    this.replacementBridgeOptions = {};
     fs.mkdirSync(this.statusDir, { recursive: true });
     fs.mkdirSync(this.projectRoot, { recursive: true });
     fs.mkdirSync(path.join(this.projectRoot, "Assets"), { recursive: true });
@@ -249,7 +251,7 @@ class ScenarioContext {
   }
 
   async replaceBridge() {
-    await this.startBridge();
+    await this.startBridge(this.replacementBridgeOptions);
   }
 
   writeStaleStatus() {
@@ -360,6 +362,7 @@ function writeStatus(statusPath, connectionPath, projectRoot, options) {
       heartbeat: options.healthHeartbeat || options.heartbeat,
       editorPid: options.editorPid ?? process.pid,
       processStart: options.processStart,
+      flags: options.healthFlags,
     });
   }
 
@@ -438,6 +441,12 @@ function resultFor(type, params) {
         message: "Fake tool packs listed.",
         data: { activeToolPacks: ["foundation"], availableToolPacks: ["foundation"] },
       };
+    case "Unity.ReadConsole":
+      return readConsoleResult(params);
+    case "Unity.ManageEditor":
+      return manageEditorResult(params);
+    case "Unity.Editor.SyncScripts":
+      return syncScriptsResult(params);
     case "Unity_RunCommand":
       return {
         success: true,
@@ -448,6 +457,10 @@ function resultFor(type, params) {
       return playModeSetResult(params);
     case "Unity.PlayMode.StepVerifier":
       return stepVerifierResult(params);
+    case "Unity.UI.QueryRuntimeLayout":
+      return uiRuntimeLayoutResult(params);
+    case "Unity.UI.InvokeControl":
+      return uiInvokeControlResult(params);
     case "Unity.Workflow.RunGpuSimulationProbe":
       return gpuSimulationProbeResult(params);
     case "Unity.Workflow.VerifyRuntimePackSelection":
@@ -455,6 +468,132 @@ function resultFor(type, params) {
     default:
       return { success: true, message: `${type} ok`, data: {} };
   }
+}
+
+function readConsoleResult(params = {}) {
+  const cursorSupplied = params.cursor !== undefined && params.cursor !== null;
+  const cursor = cursorSupplied ? Number(params.cursor) + 1 : 1;
+  return {
+    success: true,
+    message: "Fake console summary.",
+    data: {
+      cursor,
+      scannedFrom: cursorSupplied ? Number(params.cursor) : 0,
+      cursorSupplied,
+      entryCount: 0,
+      newErrors: 0,
+      newWarnings: 0,
+      staleErrorsPresent: null,
+      staleWarningsPresent: null,
+      typeCounts: {
+        error: 0,
+        warning: 0,
+        log: 0,
+        exception: 0,
+        assert: 0,
+        unknown: 0,
+      },
+      entries: [],
+    },
+  };
+}
+
+function manageEditorResult(params = {}) {
+  const action = params.action || params.Action || "GetState";
+  if (action === "GetCompactState") {
+    return {
+      success: true,
+      message: "Fake compact editor state.",
+      data: {
+        isPlaying: true,
+        isPaused: false,
+        isCompiling: false,
+        isUpdating: false,
+        isPlayingOrWillChangePlaymode: true,
+        isBuildingPlayer: false,
+        isEditorIdle: false,
+        runtimeAdvanced: true,
+        runtimeProbe: {
+          isAvailable: true,
+          hasAdvancedFrames: true,
+          updateCount: 12,
+          fixedUpdateCount: 6,
+          unscaledTime: 1.25,
+          activeSceneName: "TestScene",
+        },
+      },
+    };
+  }
+
+  return {
+    success: true,
+    message: `Fake ManageEditor ${action}.`,
+    data: {},
+  };
+}
+
+function syncScriptsResult(params = {}) {
+  const changedPaths = Array.isArray(params.changedPaths)
+    ? params.changedPaths
+    : Array.isArray(params.ChangedPaths)
+      ? params.ChangedPaths
+      : [];
+  const relevantChangedPaths = changedPaths.filter((changedPath) =>
+    /\.(cs|asmdef|asmref|rsp)$/i.test(String(changedPath || "")) ||
+    /(^|\/)package\.json$/i.test(String(changedPath || "")) ||
+    String(changedPath || "").replace(/\\/g, "/").toLowerCase() === "packages/manifest.json" ||
+    String(changedPath || "").replace(/\\/g, "/").toLowerCase() === "packages/packages-lock.json");
+  const force = params.force === true || params.Force === true;
+  const noChangesDetected = relevantChangedPaths.length === 0 && !force;
+  const refreshScheduledAfterResponse = !noChangesDetected;
+  const packageResolvePaths = relevantChangedPaths.filter((changedPath) =>
+    String(changedPath || "").replace(/\\/g, "/").toLowerCase().startsWith("packages/"));
+  const packageResolveRequested =
+    params.resolvePackages !== false &&
+    params.ResolvePackages !== false &&
+    (params.localPackageRefreshRequested === true ||
+      params.LocalPackageRefreshRequested === true ||
+      packageResolvePaths.length > 0);
+
+  return {
+    success: true,
+    message: refreshScheduledAfterResponse
+      ? "Fake script refresh scheduled."
+      : "Fake script sync ready.",
+    data: {
+      status: refreshScheduledAfterResponse ? "pending_refresh" : "ready",
+      readyForFollowUp: !refreshScheduledAfterResponse,
+      noChangesDetected,
+      changedPaths,
+      relevantChangedPaths,
+      packageResolveRequested,
+      packageResolvePaths,
+      force,
+      waitForCompile: params.waitForCompile !== false && params.WaitForCompile !== false,
+      refreshRequested: refreshScheduledAfterResponse,
+      refreshScheduledAfterResponse,
+      compileStarted: false,
+      compileObserved: false,
+      editorIdle: !refreshScheduledAfterResponse,
+      timedOut: false,
+      initialConsoleErrorCount: 0,
+      finalConsoleErrorCount: 0,
+      consoleErrorCount: 0,
+      newConsoleErrorCount: 0,
+      newConsoleErrorsDetected: false,
+      staleConsoleErrorsPresent: false,
+      consoleErrorsDetected: false,
+      consoleDelta: readConsoleResult().data,
+      warningCount: refreshScheduledAfterResponse ? 1 : 0,
+      warnings: refreshScheduledAfterResponse
+        ? [{
+            kind: "refresh_scheduled_after_response",
+            message: "Fake refresh scheduled after response.",
+          }]
+        : [],
+      finalState: {},
+    },
+  };
 }
 
 function playModeSetResult(params = {}) {
@@ -493,14 +632,15 @@ function playModeSetResult(params = {}) {
 function stepVerifierResult(params = {}) {
   const steps = Number(params.steps ?? params.Steps ?? 1);
   const warmupSteps = Number(params.warmupSteps ?? params.WarmupSteps ?? 0);
+  const forceNewError = steps === 99;
   return {
-    success: true,
-    message: "Fake paused stepping completed.",
+    success: !forceNewError,
+    message: forceNewError ? "Fake paused stepping saw a new console error." : "Fake paused stepping completed.",
     data: {
       enteredPlayMode: true,
       paused: true,
       stepsRequested: steps,
-      stepsCompleted: steps,
+      stepsCompleted: forceNewError ? Math.max(0, steps - 1) : steps,
       warmupSteps,
       warmupCompleted: warmupSteps,
       runtimeAdvanced: steps + warmupSteps > 0,
@@ -508,6 +648,46 @@ function stepVerifierResult(params = {}) {
       editorResponsiveAfter: true,
       exitAfter: params.exitAfter ?? params.ExitAfter ?? true,
       allowRealtimeRun: params.allowRealtimeRun ?? params.AllowRealtimeRun ?? false,
+      consoleDelta: {
+        newErrors: forceNewError ? 1 : 0,
+        newWarnings: 0,
+        staleErrorsPresent: true,
+        staleWarningsPresent: true,
+      },
+    },
+  };
+}
+
+function uiRuntimeLayoutResult(params = {}) {
+  const target = params.target || params.Target || "";
+  const found = target && !String(target).includes("Missing");
+  return {
+    success: true,
+    message: `Fake runtime layout found ${found ? 1 : 0} element(s).`,
+    data: {
+      rootCount: 1,
+      totalElementCount: found ? 1 : 0,
+      returnedElementCount: found ? 1 : 0,
+      warningCount: 0,
+      elements: found ? [{
+        name: target,
+        path: `Canvas/${target}`,
+        elementTypes: ["button", "selectable"],
+      }] : [],
+    },
+  };
+}
+
+function uiInvokeControlResult(params = {}) {
+  const target = params.target || params.Target || "";
+  const invoked = target && !String(target).includes("Missing");
+  return {
+    success: !!invoked,
+    message: invoked ? "Fake UI control invoked." : "Fake UI control target missing.",
+    data: {
+      target: { name: target, path: `Canvas/${target}` },
+      action: params.action || params.Action || "click",
+      actionResult: { succeeded: !!invoked },
       consoleDelta: {
         newErrors: 0,
         newWarnings: 0,
@@ -561,6 +741,7 @@ function runtimePackSelectionResult(params = {}) {
     data: {
       selectedPackId: packId,
       activeRuntimePackName: packId,
+      selectPack: params.selectPack ?? params.SelectPack ?? true,
       elementCount: 9,
       sceneLoaded: !!(params.scenePath || params.ScenePath),
       domainReloadObserved: false,
@@ -589,10 +770,12 @@ function fakeTools(withSchemas) {
     toolDescriptor("Unity_GetLensHealth", true, withSchemas),
     toolDescriptor("Unity_ListToolPacks", true, withSchemas),
     toolDescriptor("Unity_RunCommand", false, withSchemas),
+    toolDescriptor("Unity.Editor.SyncScripts", false, withSchemas),
     toolDescriptor("Unity.Editor.SetPlayMode", false, withSchemas),
     toolDescriptor("Unity.PlayMode.StepVerifier", false, withSchemas),
     toolDescriptor("Unity.Workflow.RunGpuSimulationProbe", false, withSchemas),
     toolDescriptor("Unity.Workflow.VerifyRuntimePackSelection", false, withSchemas),
+    toolDescriptor("Unity.Workflow.SelectPackThroughMainMenu", false, withSchemas),
   ];
 }
 
@@ -637,6 +820,7 @@ async function assertFullTools(client) {
   assert(names.includes("Unity_Editor_RecoverFromHang"), "tools/list should include bootstrap recovery tool");
   assert(names.includes("Unity_Workflow_RunGpuSimulationProbe"), "tools/list should include bootstrap GPU probe tool");
   assert(names.includes("Unity_Workflow_VerifyRuntimePackSelection"), "tools/list should include bootstrap pack handoff verifier");
+  assert(names.includes("Unity_Workflow_SelectPackThroughMainMenu"), "tools/list should include bootstrap Main Menu pack selection workflow");
   assert(names.includes("Unity_ListToolPacks"), "tools/list should include dynamic pack tool");
   assert(names.includes("Unity_RunCommand"), `tools/list should include dynamic mutating tool; got ${names.join(", ")}; stderr=${client.stderr}`);
   assert(response.tools.length >= 4, "tools/list should include dynamic tools plus local bootstrap helpers");
@@ -650,6 +834,37 @@ function assertIncludesAll(actual, expected, message) {
   for (const value of expected) {
     assert(actual.includes(value), `${message} missing ${value}; got ${actual.join(", ")}`);
   }
+}
+
+function writeBeeStyleLocalFilePackage(context) {
+  const packageName = "com.becool3000.unity-mcp-lens";
+  const packageRoot = path.join(context.root, "LocalLensPackage");
+  const sourcePath = path.join(packageRoot, "Editor", "Lens", "Tools", "RuntimeInvokeComponentMethodTools.cs");
+  const assemblyPath = path.join(context.projectRoot, "Library", "ScriptAssemblies", "Becool.UnityMcpLens.Editor.dll");
+  fs.mkdirSync(path.dirname(sourcePath), { recursive: true });
+  fs.mkdirSync(path.dirname(assemblyPath), { recursive: true });
+  fs.writeFileSync(path.join(packageRoot, "package.json"), JSON.stringify({ name: packageName }, null, 2));
+  fs.writeFileSync(sourcePath, "namespace FakeLens { public static class RuntimeInvokeComponentMethodTools {} }\n");
+  fs.writeFileSync(assemblyPath, "old fake assembly");
+
+  const oldTime = new Date(Date.now() - 120000);
+  const newTime = new Date(Date.now() - 1000);
+  fs.utimesSync(assemblyPath, oldTime, oldTime);
+  fs.utimesSync(sourcePath, newTime, newTime);
+
+  fs.writeFileSync(path.join(context.projectRoot, "Packages", "manifest.json"), JSON.stringify({
+    dependencies: {
+      [packageName]: `file:${packageRoot.replace(/\\/g, "/")}`,
+    },
+  }, null, 2));
+
+  return {
+    packageName,
+    packageRoot,
+    sourcePath,
+    assemblyPath,
+    assetPath: `Packages/${packageName}/Editor/Lens/Tools/RuntimeInvokeComponentMethodTools.cs`,
+  };
 }
 
 async function main() {
@@ -669,6 +884,68 @@ async function main() {
     assert.strictEqual(fastHealth.structuredContent.safeToContinue, true);
     assert.strictEqual(fastHealth.structuredContent.agent_should_stop, false);
     assert.strictEqual(commandTotal(context.commandCounts), beforeFastHealthCount, "fast health must not call the bridge");
+  });
+
+  {
+    const context = new ScenarioContext("health-paused-playmode-stable");
+    let client = null;
+    try {
+      await context.startBridge({
+        healthFlags: {
+          isPlaying: true,
+          isPaused: true,
+          isPlayingOrWillChangePlaymode: true,
+        },
+      });
+      client = new McpHostClient(context.projectRoot, context.statusDir);
+      await client.initialize();
+      const result = await client.callTool("Unity_Editor_HealthCheckFast", {});
+      assert.strictEqual(result.structuredContent.success, true, "paused play mode health should succeed");
+      assert.strictEqual(result.structuredContent.state, "unity_alive_fresh", "paused play mode must not be classified as a play transition");
+      assert.strictEqual(result.structuredContent.safeToContinue, true);
+      assert.strictEqual(result.structuredContent.data.editorBusy, false);
+    } finally {
+      if (client) await client.dispose().catch(() => {});
+      await context.dispose();
+    }
+  }
+
+  await withScenario("syncscripts-local-file-package-refresh", null, async (context, client) => {
+    await assertFullTools(client);
+    const localPackage = writeBeeStyleLocalFilePackage(context);
+    const result = await client.callTool("Unity_Editor_SyncScripts", {
+      waitForCompile: false,
+      timeoutSeconds: 2,
+    });
+
+    assert.strictEqual(context.commandCounts["Unity.Editor.SyncScripts"], 1, "host should call native SyncScripts once");
+    const syncCommand = context.commands.find((command) => command.type === "Unity.Editor.SyncScripts");
+    assert(syncCommand, "native SyncScripts command should be recorded");
+    assert(
+      Array.isArray(syncCommand.params.changedPaths) &&
+        syncCommand.params.changedPaths.includes(localPackage.assetPath),
+      `native SyncScripts should receive local file-package asset path ${localPackage.assetPath}; got ${JSON.stringify(syncCommand.params.changedPaths)}`
+    );
+    assert.strictEqual(syncCommand.params.localPackageRefreshRequested, true, "host should pass local file-package refresh hint");
+    assert.strictEqual(syncCommand.params.resolvePackages, true, "host should ask native SyncScripts to resolve packages");
+    assert(
+      Array.isArray(syncCommand.params.localPackageRefreshPaths) &&
+        syncCommand.params.localPackageRefreshPaths.includes(localPackage.assetPath),
+      `native SyncScripts should receive local package refresh paths; got ${JSON.stringify(syncCommand.params.localPackageRefreshPaths)}`
+    );
+    assert.strictEqual(result.structuredContent.success, false, "stale file-package assembly should fail follow-up readiness");
+    assert.strictEqual(result.structuredContent.data.localPackageRefreshRequested, true);
+    assert.strictEqual(result.structuredContent.data.packageResolveRequested, true);
+    assert(result.structuredContent.data.packageResolvePaths.includes(localPackage.assetPath));
+    assert.strictEqual(result.structuredContent.data.localPackageSourceNewerThanAssembly, true);
+    assert.strictEqual(result.structuredContent.data.proofStatus, "local_package_source_newer_than_assembly");
+    assert.strictEqual(result.structuredContent.data.status, "local_package_source_newer_than_assembly");
+    assert(result.structuredContent.data.localPackageRefreshPaths.includes(localPackage.assetPath));
+    const warningKinds = result.structuredContent.data.warnings.map((warning) => warning.kind);
+    assert(
+      warningKinds.includes("local_package_source_newer_than_assembly"),
+      `expected local package warning; got ${warningKinds.join(", ")}`
+    );
   });
 
   await withScenario("step-verifier-wrapper", null, async (context, client) => {
@@ -818,6 +1095,84 @@ async function main() {
     assert.strictEqual(result.structuredContent.data.verify.success, true);
   });
 
+  await withScenario("select-pack-through-main-menu", null, async (context, client) => {
+    await assertFullTools(client);
+    const result = await client.callTool("Unity_Workflow_SelectPackThroughMainMenu", {
+      packId: "garden",
+      mainMenuScenePath: "Assets/Scenes/MainMenu.unity",
+      exitAfter: true,
+      captureConsoleDelta: true,
+    });
+
+    assert.strictEqual(result.structuredContent.success, true, "Main Menu pack workflow should succeed");
+    assert.strictEqual(result.structuredContent.data.enteredPlayMode, true);
+    assert.strictEqual(result.structuredContent.data.paused, true);
+    assert.strictEqual(result.structuredContent.data.buttonFound, true);
+    assert.strictEqual(result.structuredContent.data.buttonInvoked, true);
+    assert.strictEqual(result.structuredContent.data.stepsAfterClick, 10);
+    assert.strictEqual(result.structuredContent.data.activeRuntimePackName, "garden");
+    assert.strictEqual(result.structuredContent.data.passed, true);
+    assert.strictEqual(result.structuredContent.data.timedOut, false);
+    assert.strictEqual(result.structuredContent.data.editorResponsiveAfter, true);
+    assert.strictEqual(result.structuredContent.data.consoleDelta.staleErrorsPresent, true);
+    assert.strictEqual(result.structuredContent.data.consoleDelta.newErrors, 0);
+    assert.strictEqual(result.structuredContent.data.verify.data.selectPack, false, "runtime verifier must not directly select the pack");
+
+    const interesting = context.commands
+      .map((command) => command.type)
+      .filter((type) => [
+        "Unity.PlayMode.StepVerifier",
+        "Unity.UI.QueryRuntimeLayout",
+        "Unity.UI.InvokeControl",
+        "Unity.Workflow.VerifyRuntimePackSelection",
+      ].includes(type));
+    assert.deepStrictEqual(interesting, [
+      "Unity.PlayMode.StepVerifier",
+      "Unity.UI.QueryRuntimeLayout",
+      "Unity.UI.InvokeControl",
+      "Unity.PlayMode.StepVerifier",
+      "Unity.Workflow.VerifyRuntimePackSelection",
+      "Unity.PlayMode.StepVerifier",
+    ], "Main Menu pack workflow should call runtime-safe tools in order");
+  });
+
+  await withScenario("select-pack-through-main-menu-new-console-error", null, async (context, client) => {
+    await assertFullTools(client);
+    const result = await client.callTool("Unity_Workflow_SelectPackThroughMainMenu", {
+      packId: "garden",
+      stepsAfterClick: 99,
+      exitAfter: true,
+      captureConsoleDelta: true,
+      failOnNewConsoleErrors: true,
+    });
+
+    assert.strictEqual(result.isError, true, "new console errors should fail Main Menu pack workflow");
+    assert.strictEqual(result.structuredContent.code, "UNITY_MCP_SELECT_PACK_MAIN_MENU_STEP_FAILED");
+    assert.strictEqual(result.structuredContent.data.step.data.consoleDelta.newErrors, 1);
+    assert.strictEqual(context.commandCounts["Unity.UI.InvokeControl"], 1, "button should be invoked before the new console error is detected");
+  });
+
+  {
+    const context = new ScenarioContext("select-pack-through-main-menu-entry-failure");
+    let client = null;
+    try {
+      await context.startBridge({ healthHeartbeat: new Date(Date.now() - 120000) });
+      client = new McpHostClient(context.projectRoot, context.statusDir);
+      await client.initialize();
+      const result = await client.callTool("Unity_Workflow_SelectPackThroughMainMenu", {
+        packId: "garden",
+        timeoutMs: 2000,
+      });
+      assert.strictEqual(result.isError, true, "unsafe health should block Main Menu pack workflow entry");
+      assert.strictEqual(result.structuredContent.code, "UNITY_MCP_SELECT_PACK_MAIN_MENU_ENTER_FAILED");
+      assert.strictEqual(context.commandCounts["Unity.UI.InvokeControl"] || 0, 0, "UI invoke must not run after entry failure");
+      assert.strictEqual(context.commandCounts["Unity.Workflow.VerifyRuntimePackSelection"] || 0, 0, "pack verification must not run after entry failure");
+    } finally {
+      if (client) await client.dispose().catch(() => {});
+      await context.dispose();
+    }
+  }
+
   {
     const context = new ScenarioContext("gpu-probe-entry-failure");
     let client = null;
@@ -867,6 +1222,67 @@ async function main() {
       assert.strictEqual(result.structuredContent.state, "bridge_unavailable");
       assert.strictEqual(result.structuredContent.safeToContinue, false);
       assert.strictEqual(result.structuredContent.agent_should_stop, false);
+    } finally {
+      if (client) await client.dispose().catch(() => {});
+      await context.dispose();
+    }
+  }
+
+  {
+    const context = new ScenarioContext("reload-gap-stale-bridge-fresh-health");
+    let client = null;
+    try {
+      const staleDeadPipe = makePipePath();
+      const staleDeadStatus = path.join(context.statusDir, "bridge-status-reload-gap-dead-pid.json");
+      writeStatus(staleDeadStatus, staleDeadPipe, context.projectRoot, {
+        status: "disconnected",
+        heartbeat: new Date(Date.now() - 120000),
+        toolCount: 999,
+        editorPid: 99999999,
+      });
+      const staleUnknownPidPipe = makePipePath();
+      const staleUnknownPidStatus = path.join(context.statusDir, "bridge-status-reload-gap-zero-pid.json");
+      writeStatus(staleUnknownPidStatus, staleUnknownPidPipe, context.projectRoot, {
+        status: "disconnected",
+        heartbeat: new Date(Date.now() - 120000),
+        toolCount: 999,
+        editorPid: 0,
+      });
+      const freshHealth = context.writeHealthOnly();
+
+      client = new McpHostClient(context.projectRoot, context.statusDir);
+      await client.initialize();
+      const diagnostic = await client.callTool("Unity_Bridge_ListConnections", {});
+      assert.strictEqual(diagnostic.structuredContent.data.selected ?? null, null, "dead stale bridge must not be selected during reload gap");
+      const staleDeadCandidate = diagnostic.structuredContent.data.candidates.find((candidate) => candidate.statusPath === staleDeadStatus);
+      assert(staleDeadCandidate, "stale dead-PID bridge candidate should remain diagnostic");
+      assert.strictEqual(staleDeadCandidate.selectable, false);
+      assert.strictEqual(staleDeadCandidate.basicHealth, "process_missing");
+      assert(
+        staleDeadCandidate.exclusionReasons.includes("fresh_project_editor_health_without_matching_bridge_pid"),
+        `stale dead-PID bridge should be excluded by fresh editor health; got ${staleDeadCandidate.exclusionReasons.join(", ")}`
+      );
+      const staleUnknownPidCandidate = diagnostic.structuredContent.data.candidates.find((candidate) => candidate.statusPath === staleUnknownPidStatus);
+      assert(staleUnknownPidCandidate, "stale zero-PID bridge candidate should remain diagnostic");
+      assert.strictEqual(staleUnknownPidCandidate.selectable, false);
+      assert.strictEqual(staleUnknownPidCandidate.basicHealth, "bridge_stale_unity_alive");
+      assert(
+        staleUnknownPidCandidate.exclusionReasons.includes("fresh_project_editor_health_without_matching_bridge_pid"),
+        `stale zero-PID bridge should be excluded by fresh editor health; got ${staleUnknownPidCandidate.exclusionReasons.join(", ")}`
+      );
+      const unmatchedHealth = diagnostic.structuredContent.data.unmatchedEditorHealthCandidates
+        .find((candidate) => candidate.healthPath === freshHealth);
+      const candidateHealth = diagnostic.structuredContent.data.candidates
+        .map((candidate) => candidate.editorHealth)
+        .find((candidate) => candidate && candidate.healthPath === freshHealth);
+      const visibleFreshHealth = unmatchedHealth || candidateHealth;
+      assert(visibleFreshHealth, "fresh editor health should remain visible while bridge reloads");
+      assert.strictEqual(visibleFreshHealth.basicHealth, "fresh");
+
+      const health = await client.callTool("Unity_Editor_HealthCheckFast", { includeCandidates: true });
+      assert.strictEqual(health.structuredContent.state, "bridge_unavailable");
+      assert.strictEqual(health.structuredContent.safeToContinue, false);
+      assert.strictEqual(health.structuredContent.agent_should_stop, false);
     } finally {
       if (client) await client.dispose().catch(() => {});
       await context.dispose();
@@ -982,6 +1398,18 @@ async function main() {
     assert.strictEqual(result.structuredContent.safeToContinue, false);
   });
 
+  await withScenario("fresh-bridge-ignores-dead-same-project-health", null, async (context, client) => {
+    const deadHealth = context.writeHealthOnly({ deadPid: true });
+    const result = await client.callTool("Unity_Editor_HealthCheckFast", { includeCandidates: true });
+    assert.strictEqual(result.structuredContent.state, "unity_alive_fresh");
+    assert.strictEqual(result.structuredContent.safeToContinue, true);
+    assert.strictEqual(result.structuredContent.data.selected.editorHealthBridgePidMatch, true);
+    const ignoredHealth = result.structuredContent.data.candidates.unmatchedEditorHealth
+      .find((candidate) => candidate.healthPath === deadHealth);
+    assert(ignoredHealth, "dead same-project health should remain diagnostic");
+    assert.strictEqual(ignoredHealth.basicHealth, "process_missing");
+  });
+
   await withScenario("stale-ignored", null, async (context, client) => {
     const staleStatus = context.writeStaleStatus();
     await assertFullTools(client);
@@ -1028,11 +1456,15 @@ async function main() {
 
     const staleHealthCandidate = candidates.find((candidate) => candidate.statusPath === staleHealth.foreignStatus);
     assert(staleHealthCandidate, "stale-health bridge candidate should be listed");
-    assert.strictEqual(staleHealthCandidate.basicHealth, "unity_silent");
+    assert.strictEqual(staleHealthCandidate.basicHealth, "fresh");
+    assert.strictEqual(staleHealthCandidate.editorHealth ?? null, null);
+    assert.strictEqual(staleHealthCandidate.editorHealthMatchQuality, "pid_health_present_but_not_fresh_or_not_project_matched");
 
     const pidReusedCandidate = candidates.find((candidate) => candidate.statusPath === pidReused.foreignStatus);
     assert(pidReusedCandidate, "pid-reused bridge candidate should be listed");
-    assert.strictEqual(pidReusedCandidate.basicHealth, "pid_reused");
+    assert.strictEqual(pidReusedCandidate.basicHealth, "fresh");
+    assert.strictEqual(pidReusedCandidate.editorHealth ?? null, null);
+    assert.strictEqual(pidReusedCandidate.editorHealthMatchQuality, "pid_health_present_but_not_fresh_or_not_project_matched");
 
     const malformedCandidate = diagnostic.structuredContent.data.unmatchedEditorHealthCandidates
       .find((candidate) => candidate.healthPath === malformedHealth);
@@ -1127,6 +1559,23 @@ async function main() {
       const blocked = await client.callTool("Unity_ListToolPacks", {});
       assert.strictEqual(blocked.isError, true, "unsafe session should block bridge-backed tools");
       assert.strictEqual(blocked.structuredContent.code, "UNITY_MCP_SESSION_UNSAFE");
+
+      const stablePlayFlags = { isPlaying: true, isPlayingOrWillChangePlaymode: true };
+      context.failOnceOn = "Unity.ReadConsole";
+      context.failed = false;
+      context.replacementBridgeOptions = { healthFlags: stablePlayFlags };
+      await context.startBridge({ healthFlags: stablePlayFlags });
+      const bypassed = await client.callTool("Unity_RunCommand", {
+        code: "return;",
+        title: "stable play mode bypass",
+        timeoutMs: 5000,
+      });
+      assert.strictEqual(bypassed.structuredContent.success, true, "stable Play Mode should allow RunCommand despite stale unsafe latch");
+      assert.strictEqual(context.commandCounts["Unity.ReadConsole"], 3, "ReadConsole safety probe should reconnect, retry once, then perform the delta check");
+      assert(client.stderr.includes("Allowing Unity.RunCommand while unsafe latch is set"), "host should log scoped RunCommand unsafe-latch bypass");
+
+      const afterBypass = await client.callTool("Unity_ListToolPacks", {});
+      assert.strictEqual(afterBypass.structuredContent.success, true, "successful stable Play Mode RunCommand should clear unsafe latch");
 
       await context.startBridge();
       const recovered = await client.callTool("Unity_Editor_HealthCheckFast", {});

--- a/Tools~/Test-McpHostTransportRecovery.ps1
+++ b/Tools~/Test-McpHostTransportRecovery.ps1
@@ -15,6 +15,9 @@ if (-not (Test-Path -LiteralPath $HostPath)) {
 
 $env:UNITY_MCP_LENS_HOST = [System.IO.Path]::GetFullPath($HostPath)
 node (Join-Path $PSScriptRoot "Test-McpHostTransportRecovery.js")
+if ($LASTEXITCODE -ne 0) {
+    throw "MCP host transport recovery tests failed with exit code $LASTEXITCODE."
+}
 
 function Invoke-CommandCenterStatusScannerSmoke {
     $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("LensCommandCenterScannerSmoke-" + [System.Guid]::NewGuid().ToString("N"))
@@ -130,6 +133,9 @@ finally
 '@
 
         dotnet run --project $scannerProject
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command Center status scanner smoke failed with exit code $LASTEXITCODE."
+        }
     }
     finally {
         Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
@@ -137,3 +143,283 @@ finally
 }
 
 Invoke-CommandCenterStatusScannerSmoke
+
+function Invoke-CommandCenterTelemetryScannerSmoke {
+    $tempRoot = Join-Path ([System.IO.Path]::GetTempPath()) ("LensCommandCenterTelemetrySmoke-" + [System.Guid]::NewGuid().ToString("N"))
+    New-Item -ItemType Directory -Path $tempRoot | Out-Null
+    try {
+        $scannerProject = Join-Path $tempRoot "TelemetrySmoke.csproj"
+        $programFile = Join-Path $tempRoot "Program.cs"
+        $commandCenterProject = Join-Path $repoRoot "UnityMcpLensApp~\src\UnityMcpLens.CommandCenter\UnityMcpLens.CommandCenter.csproj"
+
+        Set-Content -LiteralPath $scannerProject -Encoding UTF8 -Value @"
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0-windows</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+  </PropertyGroup>
+  <ItemGroup>
+    <ProjectReference Include="$commandCenterProject" />
+  </ItemGroup>
+</Project>
+"@
+
+        Set-Content -LiteralPath $programFile -Encoding UTF8 -Value @'
+using System.Text.Json;
+using UnityMcpLens.CommandCenter;
+
+static void Assert(bool condition, string message)
+{
+    if (!condition)
+        throw new InvalidOperationException(message);
+}
+
+string projectRoot = Path.Combine(Path.GetTempPath(), "LensTelemetryProject-" + Guid.NewGuid().ToString("N"));
+Directory.CreateDirectory(projectRoot);
+
+try
+{
+    var scanner = new TelemetryScanner(projectRoot);
+    TelemetrySnapshot missing = scanner.Scan();
+    Assert(!missing.Exists, "Missing telemetry file should return Exists=false.");
+
+    string libraryPath = Path.Combine(projectRoot, "Library");
+    Directory.CreateDirectory(libraryPath);
+    string statsPath = Path.Combine(libraryPath, "AI.Gateway.PayloadStats.jsonl");
+    File.WriteAllText(statsPath, string.Empty);
+    TelemetrySnapshot empty = scanner.Scan();
+    Assert(empty.Exists && empty.IsEmpty, "Empty telemetry file should be reported distinctly.");
+
+    DateTimeOffset now = DateTimeOffset.UtcNow;
+    var rows = new List<string>
+    {
+        "not json",
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "payload",
+            timestampUtc = now.AddSeconds(1).ToString("O"),
+            stage = "result_shaping",
+            name = "Unity.RunCommand",
+            rawBytes = 1000,
+            shapedBytes = 400,
+            durationMs = 50,
+            success = true,
+            payloadClass = "tool_result"
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "payload",
+            timestampUtc = now.AddSeconds(2).ToString("O"),
+            stage = "console",
+            name = "Unity.ReadConsole",
+            rawBytes = 200,
+            shapedBytes = 200,
+            durationMs = 20,
+            success = true,
+            payloadClass = "tool_result"
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "payload",
+            timestampUtc = now.AddSeconds(3).ToString("O"),
+            stage = "runtime",
+            name = "Unity.BadProbe",
+            rawBytes = 100,
+            shapedBytes = 50,
+            durationMs = 100,
+            success = false,
+            errorKind = "boom",
+            payloadClass = "tool_result"
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(4).ToString("O"),
+            stage = "coverage_bridge_command_request",
+            name = "register_client",
+            commandType = "register_client",
+            connectionId = "c1",
+            requestId = "r1",
+            requestBytes = 10,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(5).ToString("O"),
+            stage = "coverage_bridge_command_response",
+            name = "register_client",
+            commandType = "register_client",
+            connectionId = "c1",
+            requestId = "r1",
+            responseBytes = 100,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(6).ToString("O"),
+            stage = "coverage_bridge_command_request",
+            name = "get_manifest",
+            commandType = "get_manifest",
+            connectionId = "c1",
+            requestId = "r2",
+            requestBytes = 20,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(7).ToString("O"),
+            stage = "coverage_bridge_command_response",
+            name = "get_manifest",
+            commandType = "get_manifest",
+            connectionId = "c1",
+            requestId = "r2",
+            responseBytes = 200,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(8).ToString("O"),
+            stage = "coverage_bridge_command_request",
+            name = "get_tool_schema",
+            commandType = "get_tool_schema",
+            connectionId = "c1",
+            requestId = "r3",
+            requestBytes = 30,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(9).ToString("O"),
+            stage = "coverage_bridge_command_response",
+            name = "get_tool_schema",
+            commandType = "get_tool_schema",
+            connectionId = "c1",
+            requestId = "r3",
+            responseBytes = 300,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(10).ToString("O"),
+            stage = "coverage_bridge_command_request",
+            name = "set_tool_packs",
+            commandType = "set_tool_packs",
+            connectionId = "c1",
+            requestId = "r4",
+            requestBytes = 40,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(11).ToString("O"),
+            stage = "coverage_bridge_command_response",
+            name = "set_tool_packs",
+            commandType = "set_tool_packs",
+            connectionId = "c1",
+            requestId = "r4",
+            responseBytes = 400,
+            activeToolPacks = new[] { "foundation", "debug" },
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "bridge_coverage",
+            timestampUtc = now.AddSeconds(12).ToString("O"),
+            stage = "coverage_bridge_command_request",
+            name = "Unity.HungProbe",
+            commandType = "Unity.HungProbe",
+            connectionId = "c1",
+            requestId = "missing",
+            requestBytes = 90,
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "tool_snapshot",
+            timestampUtc = now.AddSeconds(13).ToString("O"),
+            stage = "tool_snapshot",
+            name = "snapshot",
+            snapshotHashMinimal = "same",
+            snapshotHashFull = "a",
+            success = true
+        }),
+        JsonSerializer.Serialize(new
+        {
+            schemaVersion = "unity-mcp-lens.payload-stats.v1",
+            eventKind = "tool_snapshot",
+            timestampUtc = now.AddSeconds(14).ToString("O"),
+            stage = "tool_snapshot",
+            name = "snapshot",
+            snapshotHashMinimal = "same",
+            snapshotHashFull = "b",
+            success = true
+        })
+    };
+
+    File.WriteAllLines(statsPath, rows);
+    TelemetrySnapshot snapshot = scanner.Scan();
+
+    Assert(snapshot.Exists && !snapshot.IsEmpty, "Telemetry should load after rows are written.");
+    Assert(snapshot.SkippedLineCount == 1, $"Expected 1 skipped line, got {snapshot.SkippedLineCount}.");
+    Assert(snapshot.PayloadEntryCount == 5, $"Expected 5 non-coverage rows, got {snapshot.PayloadEntryCount}.");
+    Assert(snapshot.CoverageEntryCount == 9, $"Expected 9 coverage rows, got {snapshot.CoverageEntryCount}.");
+    Assert(snapshot.RawBytes == 1300, $"Expected 1300 raw bytes, got {snapshot.RawBytes}.");
+    Assert(snapshot.ShapedBytes == 650, $"Expected 650 shaped bytes, got {snapshot.ShapedBytes}.");
+    Assert(snapshot.PayloadRowsWithSavings == 2, $"Expected 2 rows with savings, got {snapshot.PayloadRowsWithSavings}.");
+    Assert(snapshot.BridgeRequestCount == 5, $"Expected 5 bridge requests, got {snapshot.BridgeRequestCount}.");
+    Assert(snapshot.BridgeResponseCount == 4, $"Expected 4 bridge responses, got {snapshot.BridgeResponseCount}.");
+    Assert(snapshot.BridgeConnectionCount == 1, $"Expected 1 bridge connection, got {snapshot.BridgeConnectionCount}.");
+    Assert(snapshot.SetupCycleCount == 1, $"Expected 1 setup cycle, got {snapshot.SetupCycleCount}.");
+    Assert(snapshot.UnmatchedRequestCount == 1, $"Expected 1 unmatched request, got {snapshot.UnmatchedRequestCount}.");
+    Assert(snapshot.PackSetTransitionCount == 1, $"Expected 1 pack transition, got {snapshot.PackSetTransitionCount}.");
+    Assert(snapshot.ToolSnapshotCount == 2, $"Expected 2 tool snapshot rows, got {snapshot.ToolSnapshotCount}.");
+    Assert(snapshot.MinimalHashTransitions == 0, $"Expected 0 minimal transitions, got {snapshot.MinimalHashTransitions}.");
+    Assert(snapshot.FullHashTransitions == 1, $"Expected 1 full transition, got {snapshot.FullHashTransitions}.");
+    Assert(snapshot.FalseStableMinimalTransitions == 1, $"Expected 1 false-stable transition, got {snapshot.FalseStableMinimalTransitions}.");
+    Assert(snapshot.TopSavings.First().Label.Contains("Unity.RunCommand"), "Top savings should include Unity.RunCommand.");
+    Assert(snapshot.FailureClasses.Any(row => row.ErrorKind == "boom"), "Failure classes should include boom.");
+    Assert(snapshot.SlowOperations.Any(row => row.Label.Contains("Unity.BadProbe")), "Slow operations should include Unity.BadProbe.");
+    Assert(snapshot.UnmatchedRequests.Any(row => row.Command == "Unity.HungProbe"), "Unmatched requests should include Unity.HungProbe.");
+    Assert(snapshot.BuildClipboardSummary().Contains("Unity MCP Lens Telemetry"), "Clipboard summary should include title.");
+
+    Console.WriteLine("Command Center telemetry scanner smoke passed.");
+}
+finally
+{
+    Directory.Delete(projectRoot, recursive: true);
+}
+'@
+
+        dotnet run --project $scannerProject
+        if ($LASTEXITCODE -ne 0) {
+            throw "Command Center telemetry scanner smoke failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Remove-Item -LiteralPath $tempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+Invoke-CommandCenterTelemetryScannerSmoke

--- a/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/BridgeStatusItem.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/BridgeStatusItem.cs
@@ -14,6 +14,13 @@ public sealed class BridgeStatusItem
     public string Freshness { get; init; } = "unknown";
     public int EditorPid { get; init; }
     public bool EditorPidAlive { get; init; }
+    public string EditorProcessName { get; init; } = string.Empty;
+    public bool EditorProcessLooksLikeUnity { get; init; }
+    public bool CommandLineAvailable { get; init; }
+    public bool? ProjectCommandLineMatch { get; init; }
+    public string ProjectCommandLineEvidence { get; init; } = string.Empty;
+    public string EditorHealthMatchQuality { get; init; } = string.Empty;
+    public bool EditorHealthBridgePidMatch { get; init; }
     public string EditorProcessStartUtc { get; init; } = string.Empty;
     public bool PidStartMatches { get; init; } = true;
     public bool ProjectMatch { get; init; }

--- a/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/MainWindow.xaml
+++ b/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/MainWindow.xaml
@@ -30,7 +30,7 @@
                                Margin="0,4,0,0" />
                 </StackPanel>
                 <StackPanel Grid.Column="1" Orientation="Horizontal" VerticalAlignment="Center">
-                    <Button Content="Refresh" Click="RefreshButton_Click" ToolTip="Reload status files, settings, and install metadata." />
+                    <Button Content="Refresh" Click="RefreshButton_Click" ToolTip="Reload status files, settings, install metadata, and telemetry." />
                     <Button Content="Open Server Folder" Click="OpenServerFolder_Click" ToolTip="Open the installed Lens server directory." />
                     <Button Content="Open Status Folder" Click="OpenStatusFolder_Click" ToolTip="Open the bridge status directory." />
                 </StackPanel>
@@ -95,6 +95,169 @@
                                 </ListView>
                             </StackPanel>
                         </Border>
+                    </StackPanel>
+                </ScrollViewer>
+            </TabItem>
+
+            <TabItem Header="Telemetry">
+                <ScrollViewer VerticalScrollBarVisibility="Auto">
+                    <StackPanel Margin="16">
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+
+                            <Border Grid.Column="0" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,12,12">
+                                <StackPanel>
+                                    <TextBlock Text="Telemetry File" Style="{StaticResource SectionTitle}" />
+                                    <TextBlock x:Name="TelemetryStatusText" FontSize="14" TextWrapping="Wrap" />
+                                    <TextBlock x:Name="TelemetryPathText" Style="{StaticResource HintText}" Margin="0,6,0,0" TextWrapping="Wrap" />
+                                    <TextBlock x:Name="TelemetryFileInfoText" Style="{StaticResource HintText}" Margin="0,4,0,0" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="1" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,12,12">
+                                <StackPanel>
+                                    <TextBlock Text="Payload Savings" Style="{StaticResource SectionTitle}" />
+                                    <TextBlock x:Name="TelemetryPayloadSummaryText" FontSize="14" TextWrapping="Wrap" />
+                                    <TextBlock x:Name="TelemetryRowsText" Style="{StaticResource HintText}" Margin="0,6,0,0" />
+                                    <TextBlock x:Name="TelemetryDateRangeText" Style="{StaticResource HintText}" Margin="0,4,0,0" />
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="2" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,0,12">
+                                <StackPanel>
+                                    <TextBlock Text="Bridge + Snapshots" Style="{StaticResource SectionTitle}" />
+                                    <TextBlock x:Name="TelemetryBridgeSummaryText" FontSize="14" TextWrapping="Wrap" />
+                                    <TextBlock x:Name="TelemetrySnapshotSummaryText" Style="{StaticResource HintText}" Margin="0,6,0,0" TextWrapping="Wrap" />
+                                    <StackPanel Orientation="Horizontal" Margin="0,10,0,0">
+                                        <Button Content="Refresh Telemetry" Click="RefreshTelemetryButton_Click" ToolTip="Reload the project telemetry file without calling Unity." />
+                                        <Button Content="Open Telemetry File" Click="OpenTelemetryFileButton_Click" />
+                                        <Button Content="Copy Telemetry Summary" Click="CopyTelemetrySummaryButton_Click" />
+                                    </StackPanel>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Column="0" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,12,12">
+                                <StackPanel>
+                                    <TextBlock Text="Top Savings" Style="{StaticResource SectionTitle}" />
+                                    <ListView x:Name="TelemetryTopSavingsList" MinHeight="160">
+                                        <ListView.View>
+                                            <GridView>
+                                                <GridViewColumn Header="Payload" DisplayMemberBinding="{Binding Label}" Width="260" />
+                                                <GridViewColumn Header="Rows" DisplayMemberBinding="{Binding Count}" Width="70" />
+                                                <GridViewColumn Header="Raw" DisplayMemberBinding="{Binding RawBytesDisplay}" Width="90" />
+                                                <GridViewColumn Header="Saved" DisplayMemberBinding="{Binding SavedBytesDisplay}" Width="90" />
+                                                <GridViewColumn Header="Savings" DisplayMemberBinding="{Binding SavingsPctDisplay}" Width="90" />
+                                            </GridView>
+                                        </ListView.View>
+                                    </ListView>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="1" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,0,12">
+                                <StackPanel>
+                                    <TextBlock Text="Slow Operations" Style="{StaticResource SectionTitle}" />
+                                    <ListView x:Name="TelemetrySlowOperationsList" MinHeight="160">
+                                        <ListView.View>
+                                            <GridView>
+                                                <GridViewColumn Header="Operation" DisplayMemberBinding="{Binding Label}" Width="280" />
+                                                <GridViewColumn Header="Rows" DisplayMemberBinding="{Binding Count}" Width="70" />
+                                                <GridViewColumn Header="Mean ms" DisplayMemberBinding="{Binding MeanMs}" Width="90" />
+                                                <GridViewColumn Header="P95 ms" DisplayMemberBinding="{Binding P95Ms}" Width="90" />
+                                                <GridViewColumn Header="Max ms" DisplayMemberBinding="{Binding MaxMs}" Width="90" />
+                                            </GridView>
+                                        </ListView.View>
+                                    </ListView>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Column="0" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,12,12">
+                                <StackPanel>
+                                    <TextBlock Text="Top Stages" Style="{StaticResource SectionTitle}" />
+                                    <ListView x:Name="TelemetryTopStagesList" MinHeight="160">
+                                        <ListView.View>
+                                            <GridView>
+                                                <GridViewColumn Header="Stage" DisplayMemberBinding="{Binding Label}" Width="260" />
+                                                <GridViewColumn Header="Rows" DisplayMemberBinding="{Binding Count}" Width="70" />
+                                                <GridViewColumn Header="Raw" DisplayMemberBinding="{Binding RawBytesDisplay}" Width="90" />
+                                                <GridViewColumn Header="Shaped" DisplayMemberBinding="{Binding ShapedBytesDisplay}" Width="90" />
+                                                <GridViewColumn Header="Saved" DisplayMemberBinding="{Binding SavedBytesDisplay}" Width="90" />
+                                            </GridView>
+                                        </ListView.View>
+                                    </ListView>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="1" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,0,12">
+                                <StackPanel>
+                                    <TextBlock Text="Top Names" Style="{StaticResource SectionTitle}" />
+                                    <ListView x:Name="TelemetryTopNamesList" MinHeight="160">
+                                        <ListView.View>
+                                            <GridView>
+                                                <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Label}" Width="260" />
+                                                <GridViewColumn Header="Rows" DisplayMemberBinding="{Binding Count}" Width="70" />
+                                                <GridViewColumn Header="Raw" DisplayMemberBinding="{Binding RawBytesDisplay}" Width="90" />
+                                                <GridViewColumn Header="Shaped" DisplayMemberBinding="{Binding ShapedBytesDisplay}" Width="90" />
+                                                <GridViewColumn Header="Saved" DisplayMemberBinding="{Binding SavedBytesDisplay}" Width="90" />
+                                            </GridView>
+                                        </ListView.View>
+                                    </ListView>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
+
+                        <Grid>
+                            <Grid.ColumnDefinitions>
+                                <ColumnDefinition Width="*" />
+                                <ColumnDefinition Width="*" />
+                            </Grid.ColumnDefinitions>
+                            <Border Grid.Column="0" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,12,12">
+                                <StackPanel>
+                                    <TextBlock Text="Failure Classes" Style="{StaticResource SectionTitle}" />
+                                    <ListView x:Name="TelemetryFailureClassesList" MinHeight="150">
+                                        <ListView.View>
+                                            <GridView>
+                                                <GridViewColumn Header="Stage" DisplayMemberBinding="{Binding Stage}" Width="170" />
+                                                <GridViewColumn Header="Name" DisplayMemberBinding="{Binding Name}" Width="200" />
+                                                <GridViewColumn Header="Error" DisplayMemberBinding="{Binding ErrorKind}" Width="160" />
+                                                <GridViewColumn Header="Rows" DisplayMemberBinding="{Binding Count}" Width="70" />
+                                            </GridView>
+                                        </ListView.View>
+                                    </ListView>
+                                </StackPanel>
+                            </Border>
+
+                            <Border Grid.Column="1" Background="White" BorderBrush="#E2E8F0" BorderThickness="1" Padding="16" Margin="0,0,0,12">
+                                <StackPanel>
+                                    <TextBlock Text="Unmatched Requests" Style="{StaticResource SectionTitle}" />
+                                    <ListView x:Name="TelemetryUnmatchedRequestsList" MinHeight="150">
+                                        <ListView.View>
+                                            <GridView>
+                                                <GridViewColumn Header="Time" DisplayMemberBinding="{Binding TimestampUtc}" Width="150" />
+                                                <GridViewColumn Header="Command" DisplayMemberBinding="{Binding Command}" Width="170" />
+                                                <GridViewColumn Header="Connection" DisplayMemberBinding="{Binding ConnectionId}" Width="130" />
+                                                <GridViewColumn Header="Bytes" DisplayMemberBinding="{Binding RequestBytes}" Width="70" />
+                                            </GridView>
+                                        </ListView.View>
+                                    </ListView>
+                                </StackPanel>
+                            </Border>
+                        </Grid>
                     </StackPanel>
                 </ScrollViewer>
             </TabItem>

--- a/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/MainWindow.xaml.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/MainWindow.xaml.cs
@@ -12,7 +12,9 @@ public partial class MainWindow : Window
     readonly ProjectSettingsStore m_SettingsStore;
     readonly InstallerService m_InstallerService;
     readonly StatusScanner m_StatusScanner;
+    readonly TelemetryScanner m_TelemetryScanner;
     readonly DispatcherTimer m_Timer;
+    TelemetrySnapshot? m_LastTelemetrySnapshot;
 
     public MainWindow()
     {
@@ -22,6 +24,7 @@ public partial class MainWindow : Window
         m_SettingsStore = new ProjectSettingsStore(m_Options.ProjectRoot);
         m_InstallerService = new InstallerService(m_Options.PackageRoot);
         m_StatusScanner = new StatusScanner(m_Options.StatusDirectory, m_Options.ProjectRoot);
+        m_TelemetryScanner = new TelemetryScanner(m_Options.ProjectRoot);
 
         ContextText.Text = m_Options.ProjectRoot;
         m_Timer = new DispatcherTimer { Interval = TimeSpan.FromSeconds(5) };
@@ -35,6 +38,8 @@ public partial class MainWindow : Window
     }
 
     void RefreshButton_Click(object sender, RoutedEventArgs e) => LoadEverything();
+
+    void RefreshTelemetryButton_Click(object sender, RoutedEventArgs e) => _ = RefreshTelemetryAsync();
 
     void RefreshServerButton_Click(object sender, RoutedEventArgs e)
     {
@@ -82,12 +87,42 @@ public partial class MainWindow : Window
         OpenPath(m_Options.StatusDirectory);
     }
 
+    void OpenTelemetryFileButton_Click(object sender, RoutedEventArgs e)
+    {
+        string path = m_TelemetryScanner.StatsPath;
+        if (File.Exists(path))
+        {
+            OpenPath(path);
+            return;
+        }
+
+        string? directory = Path.GetDirectoryName(path);
+        if (!string.IsNullOrWhiteSpace(directory))
+        {
+            Directory.CreateDirectory(directory);
+            OpenPath(directory);
+        }
+    }
+
+    void CopyTelemetrySummaryButton_Click(object sender, RoutedEventArgs e)
+    {
+        if (m_LastTelemetrySnapshot == null)
+        {
+            StatusText.Text = "No telemetry summary loaded.";
+            return;
+        }
+
+        Clipboard.SetText(m_LastTelemetrySnapshot.BuildClipboardSummary());
+        StatusText.Text = "Telemetry summary copied.";
+    }
+
     void LoadEverything()
     {
         LoadInstallSnapshot();
         LoadSettings();
         RefreshStatusOnly();
         LoadPaths();
+        _ = RefreshTelemetryAsync();
     }
 
     void RefreshStatusOnly()
@@ -143,6 +178,49 @@ public partial class MainWindow : Window
         StatusDirectoryText.Text = $"Status directory: {m_Options.StatusDirectory}";
         SettingsPathText.Text = $"Settings file: {m_SettingsStore.SettingsPath}";
         InstalledServerPathText.Text = $"Installed server: {m_InstallerService.InstalledServerPath}";
+    }
+
+    async Task RefreshTelemetryAsync()
+    {
+        try
+        {
+            StatusText.Text = "Loading telemetry...";
+            TelemetrySnapshot snapshot = await Task.Run(() => m_TelemetryScanner.Scan()).ConfigureAwait(true);
+            RenderTelemetry(snapshot);
+            StatusText.Text = snapshot.StatusMessage;
+        }
+        catch (Exception ex)
+        {
+            StatusText.Text = "Telemetry load failed.";
+            RenderTelemetry(new TelemetrySnapshot
+            {
+                StatsPath = m_TelemetryScanner.StatsPath,
+                Exists = File.Exists(m_TelemetryScanner.StatsPath),
+                StatusMessage = $"Telemetry load failed: {ex.Message}"
+            });
+        }
+    }
+
+    void RenderTelemetry(TelemetrySnapshot snapshot)
+    {
+        m_LastTelemetrySnapshot = snapshot;
+
+        TelemetryStatusText.Text = snapshot.StatusMessage;
+        TelemetryPathText.Text = snapshot.StatsPath;
+        TelemetryFileInfoText.Text = snapshot.Exists
+            ? $"Size {snapshot.FileSizeDisplay}; last write {snapshot.LastWriteDisplay}; scope {snapshot.Scope}; next line {snapshot.NextLine:N0}"
+            : "No telemetry file exists for this project yet.";
+        TelemetryPayloadSummaryText.Text = snapshot.PayloadSummaryDisplay;
+        TelemetryRowsText.Text = snapshot.RowSummaryDisplay;
+        TelemetryDateRangeText.Text = $"Date range: {snapshot.DateRangeDisplay}";
+        TelemetryBridgeSummaryText.Text = snapshot.BridgeSummaryDisplay;
+        TelemetrySnapshotSummaryText.Text = snapshot.SnapshotSummaryDisplay;
+        TelemetryTopSavingsList.ItemsSource = snapshot.TopSavings;
+        TelemetryTopStagesList.ItemsSource = snapshot.TopStages;
+        TelemetryTopNamesList.ItemsSource = snapshot.TopNames;
+        TelemetrySlowOperationsList.ItemsSource = snapshot.SlowOperations;
+        TelemetryFailureClassesList.ItemsSource = snapshot.FailureClasses;
+        TelemetryUnmatchedRequestsList.ItemsSource = snapshot.UnmatchedRequests;
     }
 
     LensSettingsSnapshot ReadSettingsFromUi()

--- a/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/StatusScanner.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/StatusScanner.cs
@@ -78,6 +78,13 @@ public sealed class StatusScanner
                     Freshness = basicHealth,
                     EditorPid = editorHealth?.EditorPid ?? editorPid,
                     EditorPidAlive = editorHealth?.EditorPidAlive ?? editorPidAlive,
+                    EditorProcessName = editorHealth?.EditorProcessName ?? string.Empty,
+                    EditorProcessLooksLikeUnity = editorHealth?.EditorProcessLooksLikeUnity == true,
+                    CommandLineAvailable = editorHealth?.CommandLineAvailable == true,
+                    ProjectCommandLineMatch = editorHealth?.ProjectCommandLineMatch,
+                    ProjectCommandLineEvidence = editorHealth?.ProjectCommandLineEvidence ?? string.Empty,
+                    EditorHealthMatchQuality = DescribeEditorHealthMatch(healthCandidates, editorHealth, projectRoot, editorPid),
+                    EditorHealthBridgePidMatch = editorHealth != null && editorPid > 0 && editorHealth.EditorPid == editorPid,
                     EditorProcessStartUtc = editorHealth?.EditorProcessStartUtc == DateTime.MinValue || editorHealth == null
                         ? string.Empty
                         : editorHealth.EditorProcessStartUtc.ToString("O"),
@@ -149,6 +156,13 @@ public sealed class StatusScanner
             Freshness = health.IsIgnoredMalformed ? "ignored_malformed_status" : health.BasicHealth,
             EditorPid = health.EditorPid,
             EditorPidAlive = health.EditorPidAlive,
+            EditorProcessName = health.EditorProcessName ?? string.Empty,
+            EditorProcessLooksLikeUnity = health.EditorProcessLooksLikeUnity,
+            CommandLineAvailable = health.CommandLineAvailable,
+            ProjectCommandLineMatch = health.ProjectCommandLineMatch,
+            ProjectCommandLineEvidence = health.ProjectCommandLineEvidence ?? string.Empty,
+            EditorHealthMatchQuality = health.IsFresh ? "health_only_fresh" : "health_only_not_fresh",
+            EditorHealthBridgePidMatch = false,
             EditorProcessStartUtc = health.EditorProcessStartUtc == DateTime.MinValue ? string.Empty : health.EditorProcessStartUtc.ToString("O"),
             PidStartMatches = health.PidStartMatches,
             ProjectMatch = health.IsProjectMatch,
@@ -209,6 +223,28 @@ public sealed class StatusScanner
         {
             return false;
         }
+    }
+
+    static string DescribeEditorHealthMatch(EditorHealthCandidate[] candidates, EditorHealthCandidate? selectedHealth, string projectRoot, int editorPid)
+    {
+        if (selectedHealth != null)
+            return editorPid > 0 && selectedHealth.EditorPid == editorPid
+                ? "fresh_pid_project_match"
+                : "fresh_project_match_no_bridge_pid";
+
+        string normalizedProjectRoot = EditorHealthDiscovery.NormalizePath(projectRoot);
+        bool hasProjectHealth = candidates.Any(candidate =>
+            candidate.Error == null &&
+            EditorHealthDiscovery.IsBridgeProjectMatch(candidate, normalizedProjectRoot));
+        bool hasPidHealth = editorPid > 0 && candidates.Any(candidate =>
+            candidate.Error == null &&
+            candidate.EditorPid == editorPid);
+
+        if (hasPidHealth)
+            return "pid_health_present_but_not_fresh_or_not_project_matched";
+        if (hasProjectHealth)
+            return "project_health_present_but_not_matching_selected_bridge_pid";
+        return "no_matching_editor_health";
     }
 
     bool IsProjectMatch(string projectRoot)

--- a/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/TelemetryScanner.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens.CommandCenter/TelemetryScanner.cs
@@ -1,0 +1,572 @@
+using System.Globalization;
+using System.IO;
+using System.Text.Json;
+
+namespace UnityMcpLens.CommandCenter;
+
+public sealed class TelemetryScanner
+{
+    const int DefaultLastRows = 2000;
+    const int TopItemCount = 8;
+
+    readonly string m_ProjectRoot;
+
+    public TelemetryScanner(string projectRoot)
+    {
+        m_ProjectRoot = string.IsNullOrWhiteSpace(projectRoot)
+            ? Directory.GetCurrentDirectory()
+            : Path.GetFullPath(projectRoot);
+    }
+
+    public string StatsPath => Path.Combine(m_ProjectRoot, "Library", "AI.Gateway.PayloadStats.jsonl");
+
+    public TelemetrySnapshot Scan(int lastRows = DefaultLastRows)
+    {
+        string statsPath = StatsPath;
+        if (!File.Exists(statsPath))
+            return TelemetrySnapshot.Missing(statsPath);
+
+        FileInfo info = new(statsPath);
+        if (info.Length == 0)
+            return TelemetrySnapshot.Empty(statsPath, info);
+
+        lastRows = Math.Clamp(lastRows <= 0 ? DefaultLastRows : lastRows, 1, 100000);
+        List<TelemetryLine> lines = ReadLatestLines(statsPath, lastRows, out int totalLineCount);
+        List<TelemetryRow> rows = [];
+        int skippedLines = 0;
+
+        foreach (TelemetryLine line in lines)
+        {
+            try
+            {
+                using JsonDocument document = JsonDocument.Parse(line.Text);
+                rows.Add(TelemetryRow.FromJson(line.LineNumber, document.RootElement));
+            }
+            catch
+            {
+                skippedLines++;
+            }
+        }
+
+        if (rows.Count == 0)
+            return TelemetrySnapshot.NoValidRows(statsPath, info, totalLineCount, skippedLines, lines.Count > 0 ? lines[0].LineNumber : totalLineCount + 1);
+
+        return BuildSnapshot(statsPath, info, totalLineCount, skippedLines, lines[0].LineNumber, rows);
+    }
+
+    static List<TelemetryLine> ReadLatestLines(string statsPath, int lastRows, out int totalLineCount)
+    {
+        Queue<TelemetryLine> queue = new(lastRows + 1);
+        totalLineCount = 0;
+
+        foreach (string line in File.ReadLines(statsPath))
+        {
+            totalLineCount++;
+            if (string.IsNullOrWhiteSpace(line))
+                continue;
+
+            queue.Enqueue(new TelemetryLine(totalLineCount, line));
+            if (queue.Count > lastRows)
+                queue.Dequeue();
+        }
+
+        return queue.ToList();
+    }
+
+    static TelemetrySnapshot BuildSnapshot(string statsPath, FileInfo info, int totalLineCount, int skippedLines, int startLine, IReadOnlyList<TelemetryRow> rows)
+    {
+        List<TelemetryRow> scopedRows = rows.OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue).ToList();
+        List<TelemetryRow> coverageRows = scopedRows.Where(IsCoverageRow).ToList();
+        List<TelemetryRow> payloadRows = scopedRows.Where(row => !IsCoverageRow(row)).ToList();
+        List<TelemetryRow> bridgeRequestRows = coverageRows
+            .Where(row => string.Equals(row.Stage, "coverage_bridge_command_request", StringComparison.Ordinal))
+            .ToList();
+        List<TelemetryRow> bridgeResponseRows = coverageRows
+            .Where(row => string.Equals(row.Stage, "coverage_bridge_command_response", StringComparison.Ordinal))
+            .ToList();
+        List<TelemetryRow> toolSnapshotRows = scopedRows
+            .Where(row => string.Equals(row.EventKind, "tool_snapshot", StringComparison.Ordinal) ||
+                string.Equals(row.Stage, "tool_snapshot", StringComparison.Ordinal))
+            .ToList();
+
+        long rawBytes = payloadRows.Sum(row => row.RawBytes);
+        long shapedBytes = payloadRows.Sum(row => row.ShapedBytes);
+        int payloadRowsWithSavings = payloadRows.Count(row => row.RawBytes > row.ShapedBytes);
+        HashSet<string> responseKeys = new(
+            bridgeResponseRows.Select(BuildBridgeRowKey).Where(key => !string.IsNullOrWhiteSpace(key)),
+            StringComparer.Ordinal);
+        List<TelemetryUnmatchedRequestRow> allUnmatchedRequests = bridgeRequestRows
+            .Where(row => !string.IsNullOrWhiteSpace(BuildBridgeRowKey(row)) && !responseKeys.Contains(BuildBridgeRowKey(row)))
+            .Select(row => new TelemetryUnmatchedRequestRow
+            {
+                TimestampUtc = FormatTimestamp(row.TimestampUtc),
+                Command = string.IsNullOrWhiteSpace(row.CommandType) ? "(unknown)" : row.CommandType,
+                ConnectionId = string.IsNullOrWhiteSpace(row.ConnectionId) ? "(none)" : row.ConnectionId,
+                RequestId = string.IsNullOrWhiteSpace(row.RequestId) ? "(none)" : row.RequestId,
+                RequestBytes = row.RequestBytes
+            })
+            .ToList();
+        List<TelemetryUnmatchedRequestRow> unmatchedRequests = allUnmatchedRequests
+            .Take(TopItemCount)
+            .ToList();
+
+        int minimalTransitions = 0;
+        int fullTransitions = 0;
+        int falseStableMinimalTransitions = 0;
+        for (int i = 1; i < toolSnapshotRows.Count; i++)
+        {
+            TelemetryRow previous = toolSnapshotRows[i - 1];
+            TelemetryRow current = toolSnapshotRows[i];
+            if (!string.Equals(current.SnapshotHashMinimal, previous.SnapshotHashMinimal, StringComparison.Ordinal))
+                minimalTransitions++;
+            if (!string.Equals(current.SnapshotHashFull, previous.SnapshotHashFull, StringComparison.Ordinal))
+                fullTransitions++;
+            if (string.Equals(current.SnapshotHashMinimal, previous.SnapshotHashMinimal, StringComparison.Ordinal) &&
+                !string.Equals(current.SnapshotHashFull, previous.SnapshotHashFull, StringComparison.Ordinal))
+            {
+                falseStableMinimalTransitions++;
+            }
+        }
+
+        List<TelemetryRow> latencyRows = scopedRows.Where(row => row.DurationMs > 0d).ToList();
+        return new TelemetrySnapshot
+        {
+            StatsPath = statsPath,
+            Exists = true,
+            IsEmpty = false,
+            FileSizeBytes = info.Length,
+            LastWriteUtc = info.LastWriteTimeUtc,
+            Scope = $"lastRows:{rows.Count}",
+            TotalLineCount = totalLineCount,
+            StartLine = startLine,
+            NextLine = totalLineCount + 1,
+            EntryCount = scopedRows.Count,
+            PayloadEntryCount = payloadRows.Count,
+            CoverageEntryCount = coverageRows.Count,
+            SkippedLineCount = skippedLines,
+            RawBytes = rawBytes,
+            ShapedBytes = shapedBytes,
+            RawTokens = EstimateTokens(rawBytes),
+            ShapedTokens = EstimateTokens(shapedBytes),
+            PayloadRowsWithSavings = payloadRowsWithSavings,
+            BridgeRequestCount = bridgeRequestRows.Count,
+            BridgeResponseCount = bridgeResponseRows.Count,
+            BridgeConnectionCount = scopedRows
+                .Where(row => !string.IsNullOrWhiteSpace(row.ConnectionId))
+                .Select(row => row.ConnectionId)
+                .Distinct(StringComparer.Ordinal)
+                .Count(),
+            SetupCycleCount = CountSetupCycles(bridgeRequestRows),
+            UnmatchedRequestCount = allUnmatchedRequests.Count,
+            PackSetTransitionCount = bridgeResponseRows.Count(row => string.Equals(row.CommandType, "set_tool_packs", StringComparison.Ordinal)),
+            ToolSnapshotCount = toolSnapshotRows.Count,
+            MinimalHashTransitions = minimalTransitions,
+            FullHashTransitions = fullTransitions,
+            FalseStableMinimalTransitions = falseStableMinimalTransitions,
+            FirstTimestampUtc = scopedRows.FirstOrDefault()?.TimestampUtc,
+            LastTimestampUtc = scopedRows.LastOrDefault()?.TimestampUtc,
+            TopSavings = CreateSummaryRows(payloadRows.Where(row => row.RawBytes > row.ShapedBytes), row => $"{EmptyLabel(row.Stage)}:{EmptyLabel(row.Name)}", bySavings: true),
+            TopStages = CreateSummaryRows(payloadRows, row => EmptyLabel(row.Stage), bySavings: false),
+            TopNames = CreateSummaryRows(payloadRows, row => EmptyLabel(row.Name), bySavings: false),
+            SlowOperations = latencyRows
+                .GroupBy(row => $"{EmptyLabel(row.Stage)}:{EmptyLabel(row.Name)}")
+                .Select(group => CreateSlowOperationRow(group))
+                .OrderByDescending(row => row.P95Ms)
+                .ThenByDescending(row => row.MaxMs)
+                .Take(TopItemCount)
+                .ToList(),
+            FailureClasses = scopedRows
+                .Where(row => row.Success == false || !string.IsNullOrWhiteSpace(row.ErrorKind))
+                .GroupBy(row => $"{EmptyLabel(row.Stage)}|{EmptyLabel(row.Name)}|{EmptyLabel(row.ErrorKind)}")
+                .Select(group =>
+                {
+                    TelemetryRow first = group.First();
+                    return new TelemetryFailureClassRow
+                    {
+                        Stage = EmptyLabel(first.Stage),
+                        Name = EmptyLabel(first.Name),
+                        ErrorKind = EmptyLabel(first.ErrorKind),
+                        Count = group.Count()
+                    };
+                })
+                .OrderByDescending(row => row.Count)
+                .Take(TopItemCount)
+                .ToList(),
+            UnmatchedRequests = unmatchedRequests,
+            StatusMessage = "Telemetry loaded."
+        };
+    }
+
+    static List<TelemetrySummaryRow> CreateSummaryRows(IEnumerable<TelemetryRow> rows, Func<TelemetryRow, string> keySelector, bool bySavings)
+    {
+        return rows
+            .GroupBy(keySelector)
+            .Select(group => new TelemetrySummaryRow
+            {
+                Label = group.Key,
+                Count = group.Count(),
+                RawBytes = group.Sum(row => row.RawBytes),
+                ShapedBytes = group.Sum(row => row.ShapedBytes)
+            })
+            .OrderByDescending(row => bySavings ? row.SavedBytes : row.RawBytes)
+            .ThenByDescending(row => row.Count)
+            .Take(TopItemCount)
+            .ToList();
+    }
+
+    static TelemetrySlowOperationRow CreateSlowOperationRow(IGrouping<string, TelemetryRow> group)
+    {
+        List<double> values = group.Select(row => row.DurationMs).Where(value => value > 0d).OrderBy(value => value).ToList();
+        return new TelemetrySlowOperationRow
+        {
+            Label = group.Key,
+            Count = values.Count,
+            MeanMs = values.Count == 0 ? 0d : Math.Round(values.Average(), 2),
+            P95Ms = Percentile(values, 0.95d),
+            MaxMs = values.Count == 0 ? 0d : Math.Round(values[^1], 2)
+        };
+    }
+
+    static bool IsCoverageRow(TelemetryRow row)
+    {
+        if (!string.IsNullOrWhiteSpace(row.Stage) && row.Stage.StartsWith("coverage_", StringComparison.Ordinal))
+            return true;
+
+        return string.Equals(row.EventKind, "coverage", StringComparison.Ordinal) ||
+            string.Equals(row.EventKind, "bridge_coverage", StringComparison.Ordinal);
+    }
+
+    static int CountSetupCycles(IReadOnlyList<TelemetryRow> bridgeRequestRows)
+    {
+        int count = 0;
+        foreach (IGrouping<string, TelemetryRow> connectionGroup in bridgeRequestRows
+            .OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue)
+            .GroupBy(row => row.ConnectionId ?? string.Empty))
+        {
+            List<TelemetryRow> requests = connectionGroup.OrderBy(row => row.TimestampUtc ?? DateTimeOffset.MinValue).ToList();
+            foreach (TelemetryRow registerRow in requests.Where(row => string.Equals(row.CommandType, "register_client", StringComparison.Ordinal)))
+            {
+                if (!registerRow.TimestampUtc.HasValue)
+                    continue;
+
+                TelemetryRow? manifestRow = requests.FirstOrDefault(row =>
+                    row.TimestampUtc.HasValue &&
+                    row.TimestampUtc.Value > registerRow.TimestampUtc.Value &&
+                    string.Equals(row.CommandType, "get_manifest", StringComparison.Ordinal));
+                if (manifestRow?.TimestampUtc == null)
+                    continue;
+
+                if (requests.Any(row =>
+                    row.TimestampUtc.HasValue &&
+                    row.TimestampUtc.Value > manifestRow.TimestampUtc.Value &&
+                    string.Equals(row.CommandType, "get_tool_schema", StringComparison.Ordinal)))
+                {
+                    count++;
+                }
+            }
+        }
+
+        return count;
+    }
+
+    static string BuildBridgeRowKey(TelemetryRow row)
+    {
+        if (string.IsNullOrWhiteSpace(row.RequestId))
+            return string.Empty;
+
+        return $"{row.ConnectionId}|{row.RequestId}";
+    }
+
+    static long EstimateTokens(long bytes) => Math.Max(0L, (long)Math.Ceiling(bytes / 4.0d));
+
+    static double Percentile(IReadOnlyList<double> sortedValues, double percentile)
+    {
+        if (sortedValues.Count == 0)
+            return 0d;
+
+        int index = (int)Math.Ceiling(percentile * sortedValues.Count) - 1;
+        index = Math.Clamp(index, 0, sortedValues.Count - 1);
+        return Math.Round(sortedValues[index], 2);
+    }
+
+    static string EmptyLabel(string? value) => string.IsNullOrWhiteSpace(value) ? "(none)" : value;
+
+    static string FormatTimestamp(DateTimeOffset? timestamp) => timestamp.HasValue ? timestamp.Value.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture) : "unknown";
+
+    readonly record struct TelemetryLine(int LineNumber, string Text);
+}
+
+public sealed class TelemetrySnapshot
+{
+    public string StatsPath { get; init; } = string.Empty;
+    public bool Exists { get; init; }
+    public bool IsEmpty { get; init; }
+    public long FileSizeBytes { get; init; }
+    public DateTime LastWriteUtc { get; init; }
+    public string Scope { get; init; } = string.Empty;
+    public int TotalLineCount { get; init; }
+    public int StartLine { get; init; }
+    public int NextLine { get; init; }
+    public int EntryCount { get; init; }
+    public int PayloadEntryCount { get; init; }
+    public int CoverageEntryCount { get; init; }
+    public int SkippedLineCount { get; init; }
+    public long RawBytes { get; init; }
+    public long ShapedBytes { get; init; }
+    public long SavedBytes => Math.Max(0L, RawBytes - ShapedBytes);
+    public long RawTokens { get; init; }
+    public long ShapedTokens { get; init; }
+    public long SavedTokens => Math.Max(0L, RawTokens - ShapedTokens);
+    public int PayloadRowsWithSavings { get; init; }
+    public double SavingsPct => RawBytes <= 0 ? 0d : Math.Round((SavedBytes / (double)RawBytes) * 100d, 2);
+    public int BridgeRequestCount { get; init; }
+    public int BridgeResponseCount { get; init; }
+    public int BridgeConnectionCount { get; init; }
+    public int SetupCycleCount { get; init; }
+    public int UnmatchedRequestCount { get; init; }
+    public int PackSetTransitionCount { get; init; }
+    public int ToolSnapshotCount { get; init; }
+    public int MinimalHashTransitions { get; init; }
+    public int FullHashTransitions { get; init; }
+    public int FalseStableMinimalTransitions { get; init; }
+    public DateTimeOffset? FirstTimestampUtc { get; init; }
+    public DateTimeOffset? LastTimestampUtc { get; init; }
+    public List<TelemetrySummaryRow> TopSavings { get; init; } = [];
+    public List<TelemetrySummaryRow> TopStages { get; init; } = [];
+    public List<TelemetrySummaryRow> TopNames { get; init; } = [];
+    public List<TelemetrySlowOperationRow> SlowOperations { get; init; } = [];
+    public List<TelemetryFailureClassRow> FailureClasses { get; init; } = [];
+    public List<TelemetryUnmatchedRequestRow> UnmatchedRequests { get; init; } = [];
+    public string StatusMessage { get; init; } = string.Empty;
+
+    public string FileSizeDisplay => Exists ? FormatBytes(FileSizeBytes) : "missing";
+    public string LastWriteDisplay => Exists && LastWriteUtc != DateTime.MinValue ? LastWriteUtc.ToLocalTime().ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture) : "unknown";
+    public string RowSummaryDisplay => Exists ? $"{EntryCount:N0} scoped rows, {PayloadEntryCount:N0} payload, {CoverageEntryCount:N0} coverage, {SkippedLineCount:N0} skipped" : "No telemetry file found.";
+    public string PayloadSummaryDisplay => $"{FormatBytes(RawBytes)} raw -> {FormatBytes(ShapedBytes)} shaped, saved {FormatBytes(SavedBytes)} / {SavedTokens:N0} tokens ({SavingsPct:0.00}%)";
+    public string BridgeSummaryDisplay => $"{BridgeRequestCount:N0} requests, {BridgeResponseCount:N0} responses, {BridgeConnectionCount:N0} connections, {SetupCycleCount:N0} setup cycles, {UnmatchedRequestCount:N0} unmatched, {PackSetTransitionCount:N0} pack transitions";
+    public string SnapshotSummaryDisplay => $"{ToolSnapshotCount:N0} snapshot rows, {MinimalHashTransitions:N0} minimal transitions, {FullHashTransitions:N0} full transitions, {FalseStableMinimalTransitions:N0} false-stable minimal transitions";
+    public string DateRangeDisplay => FirstTimestampUtc.HasValue && LastTimestampUtc.HasValue
+        ? $"{FirstTimestampUtc.Value.ToLocalTime():yyyy-MM-dd HH:mm:ss} -> {LastTimestampUtc.Value.ToLocalTime():yyyy-MM-dd HH:mm:ss}"
+        : "unknown";
+
+    public static TelemetrySnapshot Missing(string statsPath) => new()
+    {
+        StatsPath = statsPath,
+        Exists = false,
+        StatusMessage = "Telemetry file not found. Trigger Lens activity in this project to collect usage data."
+    };
+
+    public static TelemetrySnapshot Empty(string statsPath, FileInfo info) => new()
+    {
+        StatsPath = statsPath,
+        Exists = true,
+        IsEmpty = true,
+        FileSizeBytes = 0,
+        LastWriteUtc = info.LastWriteTimeUtc,
+        StatusMessage = "Telemetry file is empty."
+    };
+
+    public static TelemetrySnapshot NoValidRows(string statsPath, FileInfo info, int totalLineCount, int skippedLines, int startLine) => new()
+    {
+        StatsPath = statsPath,
+        Exists = true,
+        FileSizeBytes = info.Length,
+        LastWriteUtc = info.LastWriteTimeUtc,
+        TotalLineCount = totalLineCount,
+        StartLine = startLine,
+        NextLine = totalLineCount + 1,
+        SkippedLineCount = skippedLines,
+        StatusMessage = "No valid telemetry rows were found in the selected scope."
+    };
+
+    public string BuildClipboardSummary()
+    {
+        return string.Join(Environment.NewLine, new[]
+        {
+            "Unity MCP Lens Telemetry",
+            $"Stats path: {StatsPath}",
+            $"Status: {StatusMessage}",
+            $"Scope: {Scope}",
+            $"Rows: {RowSummaryDisplay}",
+            $"Date range: {DateRangeDisplay}",
+            $"Payload: {PayloadSummaryDisplay}",
+            $"Bridge: {BridgeSummaryDisplay}",
+            $"Tool snapshots: {SnapshotSummaryDisplay}"
+        });
+    }
+
+    public static string FormatBytes(long bytes)
+    {
+        string[] units = ["B", "KB", "MB", "GB"];
+        double value = Math.Max(0L, bytes);
+        int unit = 0;
+        while (value >= 1024d && unit < units.Length - 1)
+        {
+            value /= 1024d;
+            unit++;
+        }
+
+        return unit == 0 ? $"{value:0} {units[unit]}" : $"{value:0.0} {units[unit]}";
+    }
+}
+
+public sealed class TelemetrySummaryRow
+{
+    public string Label { get; init; } = string.Empty;
+    public int Count { get; init; }
+    public long RawBytes { get; init; }
+    public long ShapedBytes { get; init; }
+    public long SavedBytes => Math.Max(0L, RawBytes - ShapedBytes);
+    public double SavingsPct => RawBytes <= 0 ? 0d : Math.Round((SavedBytes / (double)RawBytes) * 100d, 2);
+    public string RawBytesDisplay => TelemetrySnapshot.FormatBytes(RawBytes);
+    public string ShapedBytesDisplay => TelemetrySnapshot.FormatBytes(ShapedBytes);
+    public string SavedBytesDisplay => TelemetrySnapshot.FormatBytes(SavedBytes);
+    public string SavingsPctDisplay => $"{SavingsPct:0.00}%";
+}
+
+public sealed class TelemetrySlowOperationRow
+{
+    public string Label { get; init; } = string.Empty;
+    public int Count { get; init; }
+    public double MeanMs { get; init; }
+    public double P95Ms { get; init; }
+    public double MaxMs { get; init; }
+}
+
+public sealed class TelemetryFailureClassRow
+{
+    public string Stage { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public string ErrorKind { get; init; } = string.Empty;
+    public int Count { get; init; }
+}
+
+public sealed class TelemetryUnmatchedRequestRow
+{
+    public string TimestampUtc { get; init; } = string.Empty;
+    public string Command { get; init; } = string.Empty;
+    public string ConnectionId { get; init; } = string.Empty;
+    public string RequestId { get; init; } = string.Empty;
+    public long RequestBytes { get; init; }
+}
+
+sealed class TelemetryRow
+{
+    public int LineNumber { get; init; }
+    public DateTimeOffset? TimestampUtc { get; init; }
+    public string EventKind { get; init; } = string.Empty;
+    public string Stage { get; init; } = string.Empty;
+    public string Name { get; init; } = string.Empty;
+    public long RawBytes { get; init; }
+    public long ShapedBytes { get; init; }
+    public string ConnectionId { get; init; } = string.Empty;
+    public string RequestId { get; init; } = string.Empty;
+    public bool? Success { get; init; }
+    public bool Unchanged { get; init; }
+    public string ErrorKind { get; init; } = string.Empty;
+    public string CommandType { get; init; } = string.Empty;
+    public long RequestBytes { get; init; }
+    public double DurationMs { get; init; }
+    public string SnapshotHashMinimal { get; init; } = string.Empty;
+    public string SnapshotHashFull { get; init; } = string.Empty;
+
+    public static TelemetryRow FromJson(int lineNumber, JsonElement entry)
+    {
+        return new TelemetryRow
+        {
+            LineNumber = lineNumber,
+            TimestampUtc = ReadDate(entry, "timestampUtc"),
+            EventKind = ReadString(entry, "eventKind"),
+            Stage = ReadString(entry, "stage", ReadNestedString(entry, "meta", "stage")),
+            Name = ReadString(entry, "name"),
+            RawBytes = ReadLong(entry, "rawBytes"),
+            ShapedBytes = ReadLong(entry, "shapedBytes"),
+            ConnectionId = ReadString(entry, "connectionId", ReadNestedString(entry, "meta", "connectionId")),
+            RequestId = ReadString(entry, "requestId", ReadNestedString(entry, "meta", "requestId")),
+            Success = ReadNullableBool(entry, "success"),
+            Unchanged = ReadBool(entry, "unchanged"),
+            ErrorKind = ReadString(entry, "errorKind"),
+            CommandType = ReadString(entry, "commandType", ReadString(entry, "name")),
+            RequestBytes = ReadLong(entry, "requestBytes", ReadNestedLong(entry, "meta", "payloadBytes")),
+            DurationMs = ReadDouble(entry, "durationMs"),
+            SnapshotHashMinimal = ReadString(entry, "snapshotHashMinimal"),
+            SnapshotHashFull = ReadString(entry, "snapshotHashFull")
+        };
+    }
+
+    static DateTimeOffset? ReadDate(JsonElement entry, string name)
+    {
+        string value = ReadString(entry, name);
+        return DateTimeOffset.TryParse(value, CultureInfo.InvariantCulture, DateTimeStyles.RoundtripKind, out DateTimeOffset parsed)
+            ? parsed
+            : null;
+    }
+
+    static string ReadString(JsonElement entry, string name, string fallback = "")
+    {
+        if (!entry.TryGetProperty(name, out JsonElement value))
+            return fallback;
+
+        return value.ValueKind == JsonValueKind.String ? value.GetString() ?? fallback : value.ToString();
+    }
+
+    static string ReadNestedString(JsonElement entry, string parent, string name)
+    {
+        return entry.TryGetProperty(parent, out JsonElement parentElement) && parentElement.ValueKind == JsonValueKind.Object
+            ? ReadString(parentElement, name)
+            : string.Empty;
+    }
+
+    static long ReadLong(JsonElement entry, string name, long fallback = 0)
+    {
+        if (!entry.TryGetProperty(name, out JsonElement value))
+            return fallback;
+
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetInt64(out long parsed))
+            return parsed;
+
+        return value.ValueKind == JsonValueKind.String && long.TryParse(value.GetString(), NumberStyles.Integer, CultureInfo.InvariantCulture, out parsed)
+            ? parsed
+            : fallback;
+    }
+
+    static long ReadNestedLong(JsonElement entry, string parent, string name)
+    {
+        return entry.TryGetProperty(parent, out JsonElement parentElement) && parentElement.ValueKind == JsonValueKind.Object
+            ? ReadLong(parentElement, name)
+            : 0;
+    }
+
+    static double ReadDouble(JsonElement entry, string name)
+    {
+        if (!entry.TryGetProperty(name, out JsonElement value))
+            return 0d;
+
+        if (value.ValueKind == JsonValueKind.Number && value.TryGetDouble(out double parsed))
+            return parsed;
+
+        return value.ValueKind == JsonValueKind.String && double.TryParse(value.GetString(), NumberStyles.Float, CultureInfo.InvariantCulture, out parsed)
+            ? parsed
+            : 0d;
+    }
+
+    static bool ReadBool(JsonElement entry, string name)
+    {
+        return ReadNullableBool(entry, name) == true;
+    }
+
+    static bool? ReadNullableBool(JsonElement entry, string name)
+    {
+        if (!entry.TryGetProperty(name, out JsonElement value))
+            return null;
+
+        if (value.ValueKind == JsonValueKind.True)
+            return true;
+        if (value.ValueKind == JsonValueKind.False)
+            return false;
+
+        return value.ValueKind == JsonValueKind.String && bool.TryParse(value.GetString(), out bool parsed)
+            ? parsed
+            : null;
+    }
+}

--- a/UnityMcpLensApp~/src/UnityMcpLens.Shared/EditorHealthDiscovery.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens.Shared/EditorHealthDiscovery.cs
@@ -88,6 +88,12 @@ public sealed class EditorHealthCandidate
     public bool IsIgnoredMalformed { get; init; }
     public string? MalformedIgnoreReason { get; init; }
     public bool ProjectHashMatch { get; init; }
+    public string? EditorProcessName { get; init; }
+    public string? EditorProcessPath { get; init; }
+    public bool EditorProcessLooksLikeUnity { get; init; }
+    public bool CommandLineAvailable { get; init; }
+    public bool? ProjectCommandLineMatch { get; init; }
+    public string? ProjectCommandLineEvidence { get; init; }
 }
 
 public sealed class MalformedStatusFileInfo
@@ -137,24 +143,50 @@ public static class EditorHealthDiscovery
     {
         string normalizedProjectRoot = NormalizePath(projectRoot);
 
-        EditorHealthCandidate? pidMatch = candidates
+        EditorHealthCandidate[] projectMatches = candidates
             .Where(candidate => candidate.Error == null &&
-                editorPid > 0 &&
-                candidate.EditorPid == editorPid)
-            .OrderByDescending(candidate => IsPathMatch(candidate.ProjectRoot, normalizedProjectRoot))
-            .ThenByDescending(candidate => candidate.IsFresh)
-            .ThenByDescending(candidate => candidate.EditorHeartbeatUtc)
-            .FirstOrDefault();
+                IsBridgeProjectMatch(candidate, normalizedProjectRoot))
+            .ToArray();
+
+        EditorHealthCandidate? pidMatch = editorPid > 0
+            ? projectMatches
+                .Where(candidate => candidate.EditorPid == editorPid &&
+                    IsSelectableBridgeHealth(candidate))
+                .OrderByDescending(candidate => candidate.EditorProcessLooksLikeUnity)
+                .ThenByDescending(candidate => candidate.ProjectCommandLineMatch == true)
+                .ThenByDescending(candidate => candidate.CommandLineAvailable)
+                .ThenByDescending(candidate => candidate.EditorHeartbeatUtc)
+                .FirstOrDefault()
+            : null;
 
         if (pidMatch != null)
             return pidMatch;
 
-        return candidates
-            .Where(candidate => candidate.Error == null &&
-                IsPathMatch(candidate.ProjectRoot, normalizedProjectRoot))
-            .OrderByDescending(candidate => candidate.IsFresh)
+        if (editorPid > 0)
+            return null;
+
+        return projectMatches
+            .Where(IsSelectableBridgeHealth)
+            .OrderByDescending(candidate => candidate.EditorProcessLooksLikeUnity)
+            .ThenByDescending(candidate => candidate.ProjectCommandLineMatch == true)
+            .ThenByDescending(candidate => candidate.CommandLineAvailable)
             .ThenByDescending(candidate => candidate.EditorHeartbeatUtc)
             .FirstOrDefault();
+    }
+
+    public static bool IsBridgeProjectMatch(EditorHealthCandidate candidate, string normalizedProjectRoot)
+    {
+        return IsPathMatch(candidate.ProjectRoot, normalizedProjectRoot) || candidate.ProjectHashMatch;
+    }
+
+    public static bool IsSelectableBridgeHealth(EditorHealthCandidate candidate)
+    {
+        return candidate.IsFresh &&
+            candidate.EditorPidAlive &&
+            candidate.PidStartMatches &&
+            (!candidate.CommandLineAvailable ||
+                !candidate.EditorProcessLooksLikeUnity ||
+                candidate.ProjectCommandLineMatch == true);
     }
 
     public static string ClassifyBridgeHealth(
@@ -303,6 +335,10 @@ public static class EditorHealthDiscovery
             bool pidStartMatches = process.IsAlive && ProcessStartMatches(processStartUtc, process.StartTimeUtc);
             bool isFresh = heartbeatAge <= FreshHeartbeatThreshold && process.IsAlive && pidStartMatches;
             string basicHealth = ClassifyEditorHealth(heartbeatUtc, heartbeatAge, process.IsAlive, pidStartMatches);
+            bool commandLineAvailable = !string.IsNullOrWhiteSpace(process.CommandLine);
+            bool? projectCommandLineMatch = commandLineAvailable
+                ? CommandLineMatchesProject(process.CommandLine!, projectRoot, health.ProjectPath)
+                : null;
 
             DateTime fileWriteUtc = GetFileWriteUtc(healthPath);
             TimeSpan fileAge = fileWriteUtc == DateTime.MinValue ? TimeSpan.MaxValue : nowUtc - fileWriteUtc;
@@ -327,7 +363,17 @@ public static class EditorHealthDiscovery
                 Error = null,
                 FileWriteUtc = fileWriteUtc,
                 FileAge = fileAge,
-                ProjectHashMatch = FileNameMatchesProjectHash(healthPath, normalizedProjectPathHint)
+                ProjectHashMatch = FileNameMatchesProjectHash(healthPath, normalizedProjectPathHint),
+                EditorProcessName = process.ProcessName,
+                EditorProcessPath = process.ProcessPath,
+                EditorProcessLooksLikeUnity = ProcessLooksLikeUnity(process.ProcessName, process.ProcessPath),
+                CommandLineAvailable = commandLineAvailable,
+                ProjectCommandLineMatch = projectCommandLineMatch,
+                ProjectCommandLineEvidence = commandLineAvailable && projectCommandLineMatch == true
+                    ? "process_command_line_contains_project_path"
+                    : commandLineAvailable && projectCommandLineMatch == false
+                        ? "process_command_line_missing_project_path"
+                        : null
             };
         }
         catch (Exception ex)
@@ -393,20 +439,95 @@ public static class EditorHealthDiscovery
     static ProcessProbe ProbeProcess(int pid)
     {
         if (pid <= 0)
-            return new ProcessProbe(false, DateTime.MinValue);
+            return new ProcessProbe(false, DateTime.MinValue, null, null, null);
 
         try
         {
             using Process process = Process.GetProcessById(pid);
             if (process.HasExited)
-                return new ProcessProbe(false, DateTime.MinValue);
+                return new ProcessProbe(false, DateTime.MinValue, null, null, null);
 
-            return new ProcessProbe(true, process.StartTime.ToUniversalTime());
+            string? processName = null;
+            string? processPath = null;
+            try { processName = process.ProcessName; } catch { }
+            try { processPath = process.MainModule?.FileName; } catch { }
+
+            return new ProcessProbe(
+                true,
+                process.StartTime.ToUniversalTime(),
+                processName,
+                processPath,
+                TryReadCommandLine(pid));
         }
         catch
         {
-            return new ProcessProbe(false, DateTime.MinValue);
+            return new ProcessProbe(false, DateTime.MinValue, null, null, null);
         }
+    }
+
+    static bool ProcessLooksLikeUnity(string? processName, string? processPath)
+    {
+        static bool LooksLikeUnityName(string? value)
+        {
+            if (string.IsNullOrWhiteSpace(value))
+                return false;
+
+            string name = Path.GetFileNameWithoutExtension(value.Trim());
+            return string.Equals(name, "Unity", StringComparison.OrdinalIgnoreCase);
+        }
+
+        return LooksLikeUnityName(processName) || LooksLikeUnityName(processPath);
+    }
+
+    static string? TryReadCommandLine(int pid)
+    {
+        try
+        {
+            string procPath = $"/proc/{pid}/cmdline";
+            if (!File.Exists(procPath))
+                return null;
+
+            string raw = File.ReadAllText(procPath);
+            return raw.Replace('\0', ' ').Trim();
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static bool CommandLineMatchesProject(string commandLine, string? projectRoot, string? projectPath)
+    {
+        if (string.IsNullOrWhiteSpace(commandLine))
+            return false;
+
+        string normalizedCommandLine = commandLine.Replace('\\', '/');
+        foreach (string candidate in BuildProjectPathMatchCandidates(projectRoot, projectPath))
+        {
+            if (!string.IsNullOrWhiteSpace(candidate) &&
+                normalizedCommandLine.Contains(candidate.Replace('\\', '/'), StringComparison.OrdinalIgnoreCase))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    static IEnumerable<string> BuildProjectPathMatchCandidates(string? projectRoot, string? projectPath)
+    {
+        var candidates = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+        string normalizedRoot = NormalizeProjectRoot(projectRoot, projectPath);
+        if (!string.IsNullOrWhiteSpace(normalizedRoot))
+        {
+            candidates.Add(normalizedRoot);
+            candidates.Add(Path.Combine(normalizedRoot, "Assets"));
+        }
+
+        if (!string.IsNullOrWhiteSpace(projectPath))
+            candidates.Add(NormalizePath(projectPath));
+
+        return candidates.Where(candidate => !string.IsNullOrWhiteSpace(candidate));
     }
 
     static DateTime GetFileWriteUtc(string path)
@@ -490,5 +611,10 @@ public static class EditorHealthDiscovery
         }
     }
 
-    readonly record struct ProcessProbe(bool IsAlive, DateTime StartTimeUtc);
+    readonly record struct ProcessProbe(
+        bool IsAlive,
+        DateTime StartTimeUtc,
+        string? ProcessName,
+        string? ProcessPath,
+        string? CommandLine);
 }

--- a/UnityMcpLensApp~/src/UnityMcpLens/BridgeDiscovery.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens/BridgeDiscovery.cs
@@ -16,6 +16,8 @@ sealed class BridgeDiscoveryResult
     public required bool EditorPidAlive { get; init; }
     public required string BasicHealth { get; init; }
     public EditorHealthCandidate? EditorHealth { get; init; }
+    public string EditorHealthMatchQuality { get; init; } = "unknown";
+    public bool EditorHealthBridgePidMatch { get; init; }
     public int EditorPid => StatusFile.EditorPid;
 }
 
@@ -35,6 +37,8 @@ sealed class BridgeDiscoveryCandidate
     public required bool IsSelectable { get; init; }
     public required string BasicHealth { get; init; }
     public EditorHealthCandidate? EditorHealth { get; init; }
+    public string EditorHealthMatchQuality { get; init; } = "unknown";
+    public bool EditorHealthBridgePidMatch { get; init; }
     public int EditorPid { get; init; }
     public string? Error { get; init; }
     public string[] ExclusionReasons { get; init; } = [];
@@ -218,6 +222,10 @@ static class BridgeDiscovery
             string connectionPath = status.ConnectionPath;
             string projectRoot = NormalizeProjectRoot(status.ProjectRoot, status.ProjectPath);
             EditorHealthCandidate? editorHealth = EditorHealthDiscovery.FindBestForBridge(editorHealthCandidates, projectRoot, status.EditorPid);
+            string editorHealthMatchQuality = DescribeEditorHealthMatch(editorHealthCandidates, editorHealth, projectRoot, status.EditorPid);
+            bool editorHealthBridgePidMatch = editorHealth != null &&
+                status.EditorPid > 0 &&
+                editorHealth.EditorPid == status.EditorPid;
             bool isQuarantined = IsQuarantined(statusPath, connectionPath, quarantine);
             bool isProjectMatch = IsPathMatch(projectRoot, normalizedProjectPathHint);
             DateTime heartbeatUtc = ParseUtc(status.LastHeartbeat);
@@ -243,6 +251,12 @@ static class BridgeDiscovery
                 exclusionReasons.Add("quarantined");
             if (requireProjectMatch && !isProjectMatch)
                 exclusionReasons.Add("project_mismatch");
+            if (isProjectMatch &&
+                !isFresh &&
+                HasFreshProjectEditorHealthForDifferentPid(editorHealthCandidates, projectRoot, status.EditorPid))
+            {
+                exclusionReasons.Add("fresh_project_editor_health_without_matching_bridge_pid");
+            }
             if (IsHealthyStatus(status.Status) && !isFresh)
                 exclusionReasons.Add(editorPidAlive ? "stale_heartbeat" : "editor_pid_not_alive");
 
@@ -263,6 +277,8 @@ static class BridgeDiscovery
                 IsSelectable = isSelectable,
                 BasicHealth = basicHealth,
                 EditorHealth = editorHealth,
+                EditorHealthMatchQuality = editorHealthMatchQuality,
+                EditorHealthBridgePidMatch = editorHealthBridgePidMatch,
                 EditorPid = status.EditorPid,
                 ExclusionReasons = exclusionReasons.ToArray(),
                 FileWriteUtc = fileWriteUtc,
@@ -284,7 +300,9 @@ static class BridgeDiscovery
                 IsProjectMatch = isProjectMatch,
                 EditorPidAlive = editorPidAlive,
                 BasicHealth = basicHealth,
-                EditorHealth = editorHealth
+                EditorHealth = editorHealth,
+                EditorHealthMatchQuality = editorHealthMatchQuality,
+                EditorHealthBridgePidMatch = editorHealthBridgePidMatch
             });
         }
         catch (Exception ex)
@@ -316,6 +334,20 @@ static class BridgeDiscovery
                 ProjectHashMatch = malformed.ProjectHashMatch
             }, null);
         }
+    }
+
+    static bool HasFreshProjectEditorHealthForDifferentPid(
+        EditorHealthCandidate[] candidates,
+        string projectRoot,
+        int editorPid)
+    {
+        string normalizedProjectRoot = NormalizePath(projectRoot);
+        return candidates.Any(candidate =>
+            candidate.Error == null &&
+            candidate.EditorPid > 0 &&
+            (editorPid <= 0 || candidate.EditorPid != editorPid) &&
+            EditorHealthDiscovery.IsBridgeProjectMatch(candidate, normalizedProjectRoot) &&
+            EditorHealthDiscovery.IsSelectableBridgeHealth(candidate));
     }
 
     static string ResolveStatusDirectory()
@@ -359,6 +391,42 @@ static class BridgeDiscovery
         {
             return false;
         }
+    }
+
+    static string DescribeEditorHealthMatch(
+        EditorHealthCandidate[] candidates,
+        EditorHealthCandidate? selectedHealth,
+        string projectRoot,
+        int editorPid)
+    {
+        if (selectedHealth != null)
+        {
+            if (editorPid > 0 && selectedHealth.EditorPid == editorPid)
+            {
+                if (selectedHealth.CommandLineAvailable && selectedHealth.ProjectCommandLineMatch == true)
+                    return "fresh_pid_project_command_line_match";
+
+                return selectedHealth.CommandLineAvailable
+                    ? "fresh_pid_project_match_command_line_missing"
+                    : "fresh_pid_project_match_command_line_unavailable";
+            }
+
+            return "fresh_project_match_no_bridge_pid";
+        }
+
+        string normalizedProjectRoot = NormalizePath(projectRoot);
+        bool hasProjectHealth = candidates.Any(candidate =>
+            candidate.Error == null &&
+            EditorHealthDiscovery.IsBridgeProjectMatch(candidate, normalizedProjectRoot));
+        bool hasPidHealth = editorPid > 0 && candidates.Any(candidate =>
+            candidate.Error == null &&
+            candidate.EditorPid == editorPid);
+
+        if (hasPidHealth)
+            return "pid_health_present_but_not_fresh_or_not_project_matched";
+        if (hasProjectHealth)
+            return "project_health_present_but_not_matching_selected_bridge_pid";
+        return "no_matching_editor_health";
     }
 
     static DateTime GetFileWriteUtc(string path)

--- a/UnityMcpLensApp~/src/UnityMcpLens/Program.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens/Program.cs
@@ -46,6 +46,7 @@ sealed class UnityMcpLensHost
         "Unity_Prefab_PreviewCopyComponentSerializedValues",
         "Unity_GetLensHealth",
         "Unity_Editor_HealthCheckFast",
+        "Unity_Editor_ReloadSceneModal",
         "Unity_ListToolPacks",
         "Unity_Bridge_ListConnections",
         "Unity_ReadDetailRef",
@@ -136,6 +137,7 @@ sealed class UnityMcpLensHost
         "Unity_Editor_RecoverFromHang",
         "Unity_Workflow_RunGpuSimulationProbe",
         "Unity_Workflow_VerifyRuntimePackSelection",
+        "Unity_Workflow_SelectPackThroughMainMenu",
         "Unity_Tile_BuildSet",
         "Unity_Tilemap_Setup",
         "Unity_Tilemap_Paint",
@@ -260,6 +262,21 @@ sealed class UnityMcpLensHost
         public required TimeSpan Elapsed { get; init; }
     }
 
+    sealed class RunCommandSafetyBypassResult
+    {
+        public bool Allowed { get; init; }
+        public string Reason { get; init; } = string.Empty;
+        public string FailureKind { get; init; } = string.Empty;
+        public HostHealthEvaluation? Health { get; init; }
+        public object? RuntimeState { get; init; }
+        public object? ConsoleBefore { get; init; }
+        public object? ConsoleAfter { get; init; }
+        public bool RuntimeProbeAvailable { get; init; }
+        public bool RuntimeAdvanced { get; init; }
+        public bool PausedReady { get; init; }
+        public int NewConsoleErrorCount { get; init; }
+    }
+
     sealed class BridgeDiscoveryException : InvalidOperationException
     {
         public BridgeDiscoveryException(string message, BridgeDiscoverySnapshot snapshot)
@@ -301,6 +318,57 @@ sealed class UnityMcpLensHost
         public List<object> Attempts { get; init; } = [];
         public object? LastState { get; init; }
         public string? LastError { get; init; }
+    }
+
+    sealed class AssemblyReloadProofSnapshot
+    {
+        public bool Relevant { get; init; }
+        public string[] ChangedPaths { get; init; } = [];
+        public string[] RelevantChangedPaths { get; init; } = [];
+        public string ProjectRoot { get; init; } = string.Empty;
+        public string ScriptAssembliesPath { get; init; } = string.Empty;
+        public int AssemblyCount { get; init; }
+        public DateTime NewestAssemblyWriteUtc { get; init; } = DateTime.MinValue;
+        public DateTime NewestSourceWriteUtc { get; init; } = DateTime.MinValue;
+        public string? NewestSourcePath { get; init; }
+        public DateTime NewestLocalPackageSourceWriteUtc { get; init; } = DateTime.MinValue;
+        public string? NewestLocalPackageSourcePath { get; init; }
+        public string? NewestLocalPackageSourceAssetPath { get; init; }
+        public string[] LocalPackageSourceRoots { get; init; } = [];
+        public int LocalPackageSourceFileCount { get; init; }
+        public bool LocalPackageSourceNewerThanAssembly { get; init; }
+        public int LocalPackageSourceNewerThanAssemblyPathCount { get; init; }
+        public string[] LocalPackageSourceNewerThanAssemblyAssetPaths { get; init; } = [];
+        public string AssemblyFingerprint { get; init; } = string.Empty;
+    }
+
+    sealed class LocalPackageSourceProbe
+    {
+        public string[] Roots { get; init; } = [];
+        public int FileCount { get; init; }
+        public DateTime NewestWriteUtc { get; init; } = DateTime.MinValue;
+        public string? NewestPath { get; init; }
+        public string? NewestAssetPath { get; init; }
+        public int NewerThanAssemblyPathCount { get; init; }
+        public string[] NewerThanAssemblyAssetPaths { get; init; } = [];
+    }
+
+    sealed class LocalPackageSourceRoot
+    {
+        public required string Root { get; init; }
+        public required string PackageName { get; init; }
+    }
+
+    sealed class AssemblyReloadProofResult
+    {
+        public required string ProofStatus { get; init; }
+        public bool Relevant { get; init; }
+        public bool AssemblyChanged { get; init; }
+        public bool SourceNewerThanAssembly { get; init; }
+        public AssemblyReloadProofSnapshot? Before { get; init; }
+        public AssemblyReloadProofSnapshot? After { get; init; }
+        public string? WarningKind { get; init; }
+        public string? WarningMessage { get; init; }
     }
 
     readonly JsonSerializerOptions m_JsonOptions = new(JsonSerializerDefaults.Web)
@@ -487,6 +555,8 @@ sealed class UnityMcpLensHost
 
         m_ToolCache[ScriptUpdatingConsentModalTool.ToolName] =
             ScriptUpdatingConsentModalTool.BuildDescriptor(m_JsonOptions);
+        m_ToolCache[ReloadSceneModalTool.ToolName] =
+            ReloadSceneModalTool.BuildDescriptor(m_JsonOptions);
     }
 
     BridgeToolDescriptor[] BuildBootstrapTools()
@@ -677,7 +747,26 @@ sealed class UnityMcpLensHost
                 selectedPackId = new { type = "string", description = "Expected FallingSands pack id." },
                 scenePath = new { type = "string", description = "Optional Assets-relative .unity scene path to load before Play Mode." },
                 requirePlayMode = new { type = "boolean", description = "Require runtime verification in Play Mode. Defaults to true." },
+                selectPack = new { type = "boolean", description = "Select the pack directly before verifying. Defaults to true for compatibility." },
                 timeoutMs = new { type = "integer", description = "Host workflow timeout in milliseconds. Defaults to 60000." }
+            }
+        }, m_JsonOptions);
+
+        JsonElement selectPackThroughMainMenuInputSchema = JsonSerializer.SerializeToElement(new
+        {
+            type = "object",
+            properties = new
+            {
+                packId = new { type = "string", description = "FallingSands pack id to select through the Main Menu. Defaults to garden." },
+                mainMenuScenePath = new { type = "string", description = "Assets-relative Main Menu scene path. Defaults to Assets/Scenes/MainMenu.unity." },
+                buttonName = new { type = "string", description = "Runtime UI button GameObject name. Defaults to PackButton_{packId}." },
+                buttonSearchMethod = new { type = "string", description = "UI target search method such as by_name, by_path, or by_id. Defaults to by_name." },
+                expectedRuntimePackName = new { type = "string", description = "Expected runtime ActiveElementPackName. Defaults to a display-cased pack id." },
+                stepsAfterClick = new { type = "integer", description = "Bounded paused steps after clicking the pack button. Defaults to 10." },
+                timeoutMs = new { type = "integer", description = "Hard workflow timeout in milliseconds. Defaults to 60000." },
+                exitAfter = new { type = "boolean", description = "Exit Play Mode after verification. Defaults to true." },
+                captureConsoleDelta = new { type = "boolean", description = "Capture only console entries emitted during the workflow. Defaults to true." },
+                failOnNewConsoleErrors = new { type = "boolean", description = "Fail when new console errors appear. Defaults to true." }
             }
         }, m_JsonOptions);
 
@@ -765,8 +854,14 @@ sealed class UnityMcpLensHost
             BuildBootstrapTool(
                 "Unity_Workflow_VerifyRuntimePackSelection",
                 "Verify FallingSands Runtime Pack Selection",
-                "Selects a FallingSands pack, loads the scene when requested, enters runtime if needed, and verifies the active runtime pack.",
+                "Optionally selects a FallingSands pack, loads the scene when requested, enters runtime if needed, and verifies the active runtime pack.",
                 packVerifyInputSchema,
+                readOnlyHint: false),
+            BuildBootstrapTool(
+                "Unity_Workflow_SelectPackThroughMainMenu",
+                "Select FallingSands Pack Through Main Menu",
+                "Enters the FallingSands Main Menu through safe paused Play Mode, clicks a pack button with Unity.UI.InvokeControl, then verifies the active runtime pack without Unity.RunCommand.",
+                selectPackThroughMainMenuInputSchema,
                 readOnlyHint: false),
             BuildBootstrapTool(
                 "Unity_ListToolPacks",
@@ -858,6 +953,18 @@ sealed class UnityMcpLensHost
         if (ScriptUpdatingConsentModalTool.MatchesToolName(canonicalToolName))
         {
             var localPayload = ScriptUpdatingConsentModalTool.Execute(argumentsElement, m_JsonOptions);
+            await WriteRpcAsync(new
+            {
+                jsonrpc = "2.0",
+                id = idElement.GetValueOrDefault(),
+                result = BuildToolCallResult(localPayload, IsToolLevelError(localPayload))
+            }, cancellationToken).ConfigureAwait(false);
+            return;
+        }
+
+        if (ReloadSceneModalTool.MatchesToolName(canonicalToolName))
+        {
+            var localPayload = ReloadSceneModalTool.Execute(argumentsElement, m_JsonOptions);
             await WriteRpcAsync(new
             {
                 jsonrpc = "2.0",
@@ -990,7 +1097,8 @@ sealed class UnityMcpLensHost
             return BuildToolCallResult(payload, IsToolLevelError(payload));
         }
 
-        if (ToolNamesMatch(canonicalToolName, "Unity.RunCommand") && IsRunCommandPreflightMode(argumentsElement))
+        bool isRunCommand = ToolNamesMatch(canonicalToolName, "Unity.RunCommand");
+        if (isRunCommand && IsRunCommandPreflightMode(argumentsElement))
         {
             JsonElement payload = CreateRunCommandPreflightPayload(argumentsElement);
             return BuildToolCallResult(payload, IsToolLevelError(payload));
@@ -998,10 +1106,27 @@ sealed class UnityMcpLensHost
 
         if (IsSessionUnsafe())
         {
-            return BuildToolCallResult(CreateSessionUnsafePayload(canonicalToolName), isError: true);
+            if (isRunCommand)
+            {
+                RunCommandSafetyBypassResult bypass = await EvaluateRunCommandStablePlayModeBypassAsync(cancellationToken).ConfigureAwait(false);
+                if (bypass.Allowed)
+                {
+                    Console.Error.WriteLine($"[unity-mcp-lens] Allowing Unity.RunCommand while unsafe latch is set because stable Play Mode was proven: {bypass.Reason}");
+                }
+                else
+                {
+                    return BuildToolCallResult(
+                        CreateSessionUnsafePayload(canonicalToolName, $"Stable Play Mode RunCommand bypass was not proven: {bypass.Reason}"),
+                        isError: true);
+                }
+            }
+            else
+            {
+                return BuildToolCallResult(CreateSessionUnsafePayload(canonicalToolName), isError: true);
+            }
         }
 
-        if (ToolNamesMatch(canonicalToolName, "Unity.RunCommand"))
+        if (isRunCommand)
         {
             JsonElement payload = await CallRunCommandWithWatchdogAsync(toolName, canonicalToolName, argumentsElement, cancellationToken).ConfigureAwait(false);
             return BuildToolCallResult(payload, IsToolLevelError(payload));
@@ -1030,6 +1155,12 @@ sealed class UnityMcpLensHost
         if (ToolNamesMatch(canonicalToolName, "Unity.Workflow.VerifyRuntimePackSelection"))
         {
             JsonElement payload = await CreateVerifyRuntimePackSelectionPayloadAsync(argumentsElement, cancellationToken).ConfigureAwait(false);
+            return BuildToolCallResult(payload, IsToolLevelError(payload));
+        }
+
+        if (ToolNamesMatch(canonicalToolName, "Unity.Workflow.SelectPackThroughMainMenu"))
+        {
+            JsonElement payload = await CreateSelectPackThroughMainMenuPayloadAsync(argumentsElement, cancellationToken).ConfigureAwait(false);
             return BuildToolCallResult(payload, IsToolLevelError(payload));
         }
 
@@ -1973,7 +2104,7 @@ sealed class UnityMcpLensHost
         BridgeDiscoverySnapshot snapshot = BridgeDiscovery.FindBridgeSnapshot(projectPathHint, quarantineIds, requireProjectMatch);
         BridgeDiscoveryResult? selected = snapshot.Selected;
         UnityMcpLens.Shared.EditorHealthCandidate? editorHealth =
-            selected?.EditorHealth ?? SelectBestEditorHealth(snapshot, requireProjectMatch);
+            selected != null ? selected.EditorHealth : SelectBestEditorHealth(snapshot, requireProjectMatch);
         bool editorBusy = IsEditorBusy(editorHealth);
         bool usableBridge = selected is { IsFresh: true };
         HostStopContract contract = ClassifyHealth(snapshot, selected, editorHealth, editorBusy, usableBridge);
@@ -2180,11 +2311,12 @@ sealed class UnityMcpLensHost
     static bool IsEditorBusy(UnityMcpLens.Shared.EditorHealthCandidate? editorHealth)
     {
         var health = editorHealth?.HealthFile;
+        bool playModeTransition = health?.IsPlayingOrWillChangePlaymode == true && health.IsPlaying != true;
         return health != null && (
             health.IsCompiling ||
             health.IsImporting ||
             health.IsUpdating ||
-            health.IsPlayingOrWillChangePlaymode ||
+            playModeTransition ||
             health.IsBuildingPlayer);
     }
 
@@ -2259,7 +2391,7 @@ sealed class UnityMcpLensHost
 
     void ApplyHealthEvaluationToSessionSafety(HostHealthEvaluation evaluation)
     {
-        if (evaluation.Contract.SafeToContinue && evaluation.UsableBridge && !evaluation.EditorBusy)
+        if (HasProvenFreshBridgeEditorPair(evaluation))
         {
             ClearSessionSafety();
             return;
@@ -2298,6 +2430,44 @@ sealed class UnityMcpLensHost
         m_SessionSafety.LastProjectPath = null;
         m_SessionSafety.LastStatusPath = null;
         m_SessionSafety.LastConnectionPath = null;
+    }
+
+    static bool HasProvenFreshBridgeEditorPair(HostHealthEvaluation evaluation)
+    {
+        BridgeDiscoveryResult? selected = evaluation.SelectedBridge;
+        UnityMcpLens.Shared.EditorHealthCandidate? health = evaluation.EditorHealth;
+        if (!evaluation.Contract.SafeToContinue ||
+            evaluation.EditorBusy ||
+            selected?.IsFresh != true ||
+            health?.IsFresh != true)
+        {
+            return false;
+        }
+
+        bool pidMatches = selected.EditorPid <= 0 || health.EditorPid == selected.EditorPid;
+        bool projectMatches = UnityMcpLens.Shared.EditorHealthDiscovery.IsBridgeProjectMatch(
+            health,
+            selected.ProjectRoot);
+        bool commandLineMatches = !health.CommandLineAvailable ||
+            !health.EditorProcessLooksLikeUnity ||
+            health.ProjectCommandLineMatch == true;
+        return pidMatches && projectMatches && commandLineMatches;
+    }
+
+    static bool HasProvenFreshBridgeEditorPair(BridgeDiscoveryResult selected)
+    {
+        UnityMcpLens.Shared.EditorHealthCandidate? health = selected.EditorHealth;
+        if (selected.IsFresh != true || health?.IsFresh != true)
+            return false;
+
+        bool pidMatches = selected.EditorPid <= 0 || health.EditorPid == selected.EditorPid;
+        bool projectMatches = UnityMcpLens.Shared.EditorHealthDiscovery.IsBridgeProjectMatch(
+            health,
+            selected.ProjectRoot);
+        bool commandLineMatches = !health.CommandLineAvailable ||
+            !health.EditorProcessLooksLikeUnity ||
+            health.ProjectCommandLineMatch == true;
+        return pidMatches && projectMatches && commandLineMatches;
     }
 
     object CreateSessionSafetyDiagnostics()
@@ -2849,6 +3019,8 @@ sealed class UnityMcpLensHost
 
         bool connected = m_BridgeConnection != null &&
             string.Equals(m_BridgeConnection.ProjectRoot, selected!.ProjectRoot, StringComparison.OrdinalIgnoreCase);
+        if (connectError == null && HasProvenFreshBridgeEditorPair(selected!))
+            ClearSessionSafety();
 
         return JsonSerializer.SerializeToElement(new
         {
@@ -2894,13 +3066,16 @@ sealed class UnityMcpLensHost
         JsonElement syncRequest = default;
         HostSyncReadyResult? ready = null;
         bool hostWaitAttempted = false;
+        AssemblyReloadProofSnapshot? assemblyProofBefore = CaptureAssemblyReloadProofSnapshot(argumentsElement);
+        JsonElement nativeArgumentsElement = BuildSyncScriptsNativeArguments(argumentsElement, assemblyProofBefore);
+        bool localPackageRefreshRequested = assemblyProofBefore?.LocalPackageSourceNewerThanAssemblyAssetPaths.Length > 0;
 
         try
         {
             packActivation = await EnsureScriptSyncPacksActiveAsync(cancellationToken).ConfigureAwait(false);
             syncRequest = await CallBridgeToolResultAsync(
                 "Unity.Editor.SyncScripts",
-                argumentsElement,
+                nativeArgumentsElement,
                 cancellationToken).ConfigureAwait(false);
 
             bool hasNativeData = TryGetNestedProperty(syncRequest, out var nativeData, "data");
@@ -2911,6 +3086,8 @@ sealed class UnityMcpLensHost
             bool nativeRefused = GetJsonBool(nativeData, false, "refused");
             bool nativeTimedOut = GetJsonBool(nativeData, false, "timedOut");
             bool nativeNewConsoleErrorsDetected = GetJsonBool(nativeData, false, "newConsoleErrorsDetected", "consoleErrorsDetected");
+            bool nativeCompileObserved = GetJsonBool(nativeData, false, "compileObserved");
+            bool nativePackageResolveRequested = GetJsonBool(nativeData, false, "packageResolveRequested");
             int initialConsoleErrorCount = GetJsonInt(nativeData, 0, "initialConsoleErrorCount");
             int nativeFinalConsoleErrorCount = GetJsonInt(
                 nativeData,
@@ -2966,20 +3143,42 @@ sealed class UnityMcpLensHost
                 : nativeNewConsoleErrorCount;
             bool newConsoleErrorsDetected = newConsoleErrorCount > 0;
             bool staleConsoleErrorsPresent = finalConsoleErrorCount > 0 && !newConsoleErrorsDetected;
+            object[] nativeWarnings = CloneJsonArray(nativeData, "warnings") ?? [];
+            var warnings = new List<object>(nativeWarnings);
+            AssemblyReloadProofSnapshot? assemblyProofAfter = CaptureAssemblyReloadProofSnapshot(nativeArgumentsElement);
+            AssemblyReloadProofResult assemblyReloadProof = BuildAssemblyReloadProofResult(
+                assemblyProofBefore,
+                assemblyProofAfter,
+                nativeCompileObserved,
+                finalTimedOut,
+                nativeRefused);
+            if (assemblyReloadProof.WarningKind != null)
+            {
+                warnings.Add(new
+                {
+                    kind = assemblyReloadProof.WarningKind,
+                    message = assemblyReloadProof.WarningMessage,
+                    proofStatus = assemblyReloadProof.ProofStatus
+                });
+            }
+
+            if (assemblyReloadProof.SourceNewerThanAssembly)
+                finalReadyForFollowUp = false;
+
             string finalStatus = finalReadyForFollowUp
                 ? "ready"
                 : !consoleCheckSucceeded
                     ? "console_check_failed"
                     : newConsoleErrorsDetected
                         ? "console_errors"
+                        : assemblyReloadProof.SourceNewerThanAssembly
+                            ? assemblyReloadProof.ProofStatus
                         : finalTimedOut
                             ? "timed_out"
                             : nativeRefused
                                 ? "refused"
                                 : nativeStatus ?? "failed";
             int elapsedMs = (int)Math.Round((DateTime.UtcNow - startedUtc).TotalMilliseconds);
-            object[] nativeWarnings = CloneJsonArray(nativeData, "warnings") ?? [];
-            var warnings = new List<object>(nativeWarnings);
             if (hostWaitAttempted && ready?.ConsoleCheckSucceeded == false)
             {
                 warnings.Add(new
@@ -3002,6 +3201,13 @@ sealed class UnityMcpLensHost
                     noChangesDetected = GetJsonBool(nativeData, false, "noChangesDetected"),
                     changedPaths = CloneJsonProperty(nativeData, "changedPaths"),
                     relevantChangedPaths = CloneJsonProperty(nativeData, "relevantChangedPaths"),
+                    localPackageRefreshRequested,
+                    localPackageRefreshPaths = assemblyProofBefore?.LocalPackageSourceNewerThanAssemblyAssetPaths ?? [],
+                    packageResolveRequested = localPackageRefreshRequested || nativePackageResolveRequested,
+                    nativePackageResolveRequested,
+                    packageResolvePaths = CloneJsonProperty(nativeData, "packageResolvePaths") ??
+                        assemblyProofBefore?.LocalPackageSourceNewerThanAssemblyAssetPaths ??
+                        [],
                     force = GetJsonBool(nativeData, false, "force"),
                     waitForCompile,
                     refreshRequested = GetJsonBool(nativeData, false, "refreshRequested"),
@@ -3010,7 +3216,12 @@ sealed class UnityMcpLensHost
                     hostWaitAttempted,
                     hostWaitCompleted = hostWaitAttempted && ready?.EditorIdle == true,
                     compileStarted = GetJsonBool(nativeData, false, "compileStarted"),
-                    compileObserved = GetJsonBool(nativeData, false, "compileObserved"),
+                    compileObserved = nativeCompileObserved,
+                    assemblyReloadProof,
+                    assemblyChanged = assemblyReloadProof.AssemblyChanged,
+                    sourceNewerThanAssembly = assemblyReloadProof.SourceNewerThanAssembly,
+                    localPackageSourceNewerThanAssembly = assemblyReloadProof.After?.LocalPackageSourceNewerThanAssembly == true,
+                    proofStatus = assemblyReloadProof.ProofStatus,
                     editorIdle = hostWaitAttempted ? ready?.EditorIdle == true : GetJsonBool(nativeData, false, "editorIdle"),
                     timedOut = finalTimedOut,
                     initialConsoleErrorCount,
@@ -3075,12 +3286,45 @@ sealed class UnityMcpLensHost
                     waitForCompile,
                     captureConsoleDelta,
                     syncRequest,
+                    nativeArguments = nativeArgumentsElement,
                     packActivation,
                     startingActivePacks,
                     activeToolPacks = m_ActiveToolPacks,
                     host = CreateHostDiagnostics()
                 });
         }
+    }
+
+    JsonElement BuildSyncScriptsNativeArguments(JsonElement argumentsElement, AssemblyReloadProofSnapshot? proofSnapshot)
+    {
+        string[] localPackageRefreshPaths = proofSnapshot?.LocalPackageSourceNewerThanAssemblyAssetPaths ?? [];
+        if (localPackageRefreshPaths.Length == 0)
+            return argumentsElement;
+
+        JsonObject argumentsObject = JsonNode.Parse(argumentsElement.GetRawText()) as JsonObject ?? new JsonObject();
+        var changedPaths = new SortedSet<string>(StringComparer.OrdinalIgnoreCase);
+        foreach (string path in GetJsonStringArray(argumentsElement, "changedPaths", "ChangedPaths"))
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                changedPaths.Add(path);
+        }
+
+        foreach (string path in localPackageRefreshPaths)
+        {
+            if (!string.IsNullOrWhiteSpace(path))
+                changedPaths.Add(path);
+        }
+
+        var changedPathArray = new JsonArray();
+        foreach (string path in changedPaths)
+            changedPathArray.Add(path);
+
+        argumentsObject["changedPaths"] = changedPathArray;
+        argumentsObject["localPackageRefreshRequested"] = true;
+        argumentsObject["localPackageRefreshPaths"] = JsonSerializer.SerializeToNode(localPackageRefreshPaths, m_JsonOptions);
+        argumentsObject["localPackageRefreshPathCount"] = localPackageRefreshPaths.Length;
+        argumentsObject["resolvePackages"] = true;
+        return JsonSerializer.SerializeToElement(argumentsObject, m_JsonOptions);
     }
 
     async Task<object> EnsureScriptSyncPacksActiveAsync(CancellationToken cancellationToken)
@@ -3142,6 +3386,465 @@ sealed class UnityMcpLensHost
             activeToolPacks = m_ActiveToolPacks,
             toolsListChangedNotificationSent
         };
+    }
+
+    AssemblyReloadProofSnapshot CaptureAssemblyReloadProofSnapshot(JsonElement argumentsElement)
+    {
+        string projectRoot = ResolveProjectPathHint(out _);
+        string[] changedPaths = GetJsonStringArray(argumentsElement, "changedPaths", "ChangedPaths");
+        string[] relevantChangedPaths = changedPaths
+            .Select(path => NormalizeUnityChangedPath(projectRoot, path))
+            .Where(path => !string.IsNullOrWhiteSpace(path))
+            .Where(IsCompileAffectingPath)
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(path => path, StringComparer.Ordinal)
+            .ToArray();
+        bool force = ExtractBool(argumentsElement, false, "force", "Force");
+        string scriptAssembliesPath = Path.Combine(projectRoot, "Library", "ScriptAssemblies");
+        FileInfo[] assemblyFiles = Directory.Exists(scriptAssembliesPath)
+            ? new DirectoryInfo(scriptAssembliesPath)
+                .EnumerateFiles("*.dll", SearchOption.TopDirectoryOnly)
+                .OrderBy(file => file.FullName, StringComparer.OrdinalIgnoreCase)
+                .ToArray()
+            : [];
+        DateTime newestAssemblyWriteUtc = assemblyFiles.Length == 0
+            ? DateTime.MinValue
+            : assemblyFiles.Max(file => file.LastWriteTimeUtc);
+        DateTime newestChangedSourceWriteUtc = GetNewestSourceWriteUtc(projectRoot, relevantChangedPaths, out string? newestChangedSourcePath);
+        LocalPackageSourceProbe localPackageProbe = FindLocalPackageCompileSourceProbe(projectRoot, newestAssemblyWriteUtc);
+        DateTime newestSourceWriteUtc = newestChangedSourceWriteUtc >= localPackageProbe.NewestWriteUtc
+            ? newestChangedSourceWriteUtc
+            : localPackageProbe.NewestWriteUtc;
+        string? newestSourcePath = newestChangedSourceWriteUtc >= localPackageProbe.NewestWriteUtc
+            ? newestChangedSourcePath
+            : localPackageProbe.NewestPath;
+        bool localPackageSourceNewerThanAssembly = localPackageProbe.NewestWriteUtc != DateTime.MinValue &&
+            newestAssemblyWriteUtc != DateTime.MinValue &&
+            localPackageProbe.NewestWriteUtc > newestAssemblyWriteUtc.AddSeconds(1);
+
+        return new AssemblyReloadProofSnapshot
+        {
+            Relevant = force || relevantChangedPaths.Length > 0 || localPackageSourceNewerThanAssembly,
+            ChangedPaths = changedPaths,
+            RelevantChangedPaths = relevantChangedPaths,
+            ProjectRoot = projectRoot,
+            ScriptAssembliesPath = scriptAssembliesPath,
+            AssemblyCount = assemblyFiles.Length,
+            NewestAssemblyWriteUtc = newestAssemblyWriteUtc,
+            NewestSourceWriteUtc = newestSourceWriteUtc,
+            NewestSourcePath = newestSourcePath,
+            NewestLocalPackageSourceWriteUtc = localPackageProbe.NewestWriteUtc,
+            NewestLocalPackageSourcePath = localPackageProbe.NewestPath,
+            NewestLocalPackageSourceAssetPath = localPackageProbe.NewestAssetPath,
+            LocalPackageSourceRoots = localPackageProbe.Roots,
+            LocalPackageSourceFileCount = localPackageProbe.FileCount,
+            LocalPackageSourceNewerThanAssembly = localPackageSourceNewerThanAssembly,
+            LocalPackageSourceNewerThanAssemblyPathCount = localPackageProbe.NewerThanAssemblyPathCount,
+            LocalPackageSourceNewerThanAssemblyAssetPaths = localPackageProbe.NewerThanAssemblyAssetPaths,
+            AssemblyFingerprint = string.Join("|", assemblyFiles.Select(file =>
+                $"{file.Name}:{file.Length}:{file.LastWriteTimeUtc.Ticks}"))
+        };
+    }
+
+    static AssemblyReloadProofResult BuildAssemblyReloadProofResult(
+        AssemblyReloadProofSnapshot? before,
+        AssemblyReloadProofSnapshot? after,
+        bool compileObserved,
+        bool timedOut,
+        bool refused)
+    {
+        if (after?.Relevant != true)
+        {
+            return new AssemblyReloadProofResult
+            {
+                ProofStatus = "not_required",
+                Relevant = false,
+                Before = before,
+                After = after
+            };
+        }
+
+        bool assemblyChanged = before != null &&
+            !string.Equals(before.AssemblyFingerprint, after.AssemblyFingerprint, StringComparison.Ordinal);
+        bool sourceNewerThanAssembly = after.NewestSourceWriteUtc != DateTime.MinValue &&
+            after.NewestAssemblyWriteUtc != DateTime.MinValue &&
+            after.NewestSourceWriteUtc > after.NewestAssemblyWriteUtc.AddSeconds(1);
+        bool localPackageSourceNewerThanAssembly = sourceNewerThanAssembly &&
+            after.LocalPackageSourceNewerThanAssembly;
+        string proofStatus =
+            refused ? "refused" :
+            timedOut ? "timed_out" :
+            after.AssemblyCount == 0 ? "unavailable_no_script_assemblies" :
+            localPackageSourceNewerThanAssembly ? "local_package_source_newer_than_assembly" :
+            sourceNewerThanAssembly ? "source_newer_than_assembly" :
+            assemblyChanged ? "assembly_changed" :
+            compileObserved ? "compile_observed_no_assembly_change" :
+            "assembly_reload_not_observed";
+
+        bool warnReloadNotObserved = proofStatus == "assembly_reload_not_observed" ||
+            (!compileObserved && !assemblyChanged && after.AssemblyCount > 0 && !sourceNewerThanAssembly);
+
+        return new AssemblyReloadProofResult
+        {
+            ProofStatus = proofStatus,
+            Relevant = true,
+            AssemblyChanged = assemblyChanged,
+            SourceNewerThanAssembly = sourceNewerThanAssembly,
+            Before = before,
+            After = after,
+            WarningKind = localPackageSourceNewerThanAssembly
+                ? "local_package_source_newer_than_assembly"
+                : sourceNewerThanAssembly
+                ? "source_newer_than_script_assembly"
+                : warnReloadNotObserved
+                    ? "assembly_reload_not_observed"
+                    : null,
+            WarningMessage = localPackageSourceNewerThanAssembly
+                ? "Local file-package source is newer than the newest loaded script assembly after Unity became idle; Lens requested package asset refresh/import paths but Unity has not loaded the updated assembly yet."
+                : sourceNewerThanAssembly
+                ? "Changed source is newer than the newest loaded script assembly after Unity became idle."
+                : warnReloadNotObserved
+                    ? "Relevant script changes were supplied, but Lens did not observe compilation or a script assembly timestamp change."
+                    : null
+        };
+    }
+
+    static DateTime GetNewestSourceWriteUtc(string projectRoot, string[] relevantChangedPaths, out string? newestPath)
+    {
+        DateTime newest = DateTime.MinValue;
+        newestPath = null;
+        foreach (string path in relevantChangedPaths)
+        {
+            string fullPath = Path.IsPathRooted(path) ? path : Path.Combine(projectRoot, path);
+            try
+            {
+                if (File.Exists(fullPath))
+                {
+                    DateTime writeUtc = File.GetLastWriteTimeUtc(fullPath);
+                    if (writeUtc > newest)
+                    {
+                        newest = writeUtc;
+                        newestPath = fullPath;
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return newest;
+    }
+
+    static LocalPackageSourceProbe FindLocalPackageCompileSourceProbe(string projectRoot, DateTime newestAssemblyWriteUtc)
+    {
+        LocalPackageSourceRoot[] roots = ResolveLocalPackageSourceRoots(projectRoot);
+        DateTime newest = DateTime.MinValue;
+        string? newestPath = null;
+        string? newestAssetPath = null;
+        int fileCount = 0;
+        int newerThanAssemblyPathCount = 0;
+        var newerThanAssemblyAssetPaths = new List<string>();
+
+        foreach (LocalPackageSourceRoot root in roots)
+        {
+            foreach (string file in EnumerateCompileAffectingSourceFiles(root.Root))
+            {
+                try
+                {
+                    fileCount++;
+                    DateTime writeUtc = File.GetLastWriteTimeUtc(file);
+                    string? assetPath = ToPackageAssetPath(root, file);
+                    if (writeUtc > newest)
+                    {
+                        newest = writeUtc;
+                        newestPath = file;
+                        newestAssetPath = assetPath;
+                    }
+
+                    if (!string.IsNullOrWhiteSpace(assetPath) &&
+                        newestAssemblyWriteUtc != DateTime.MinValue &&
+                        writeUtc > newestAssemblyWriteUtc.AddSeconds(1))
+                    {
+                        newerThanAssemblyPathCount++;
+                        if (newerThanAssemblyAssetPaths.Count < 64)
+                            newerThanAssemblyAssetPaths.Add(assetPath);
+                    }
+                }
+                catch
+                {
+                }
+            }
+        }
+
+        return new LocalPackageSourceProbe
+        {
+            Roots = roots.Select(root => root.Root).ToArray(),
+            FileCount = fileCount,
+            NewestWriteUtc = newest,
+            NewestPath = newestPath,
+            NewestAssetPath = newestAssetPath,
+            NewerThanAssemblyPathCount = newerThanAssemblyPathCount,
+            NewerThanAssemblyAssetPaths = newerThanAssemblyAssetPaths
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .OrderBy(path => path, StringComparer.Ordinal)
+                .ToArray()
+        };
+    }
+
+    static LocalPackageSourceRoot[] ResolveLocalPackageSourceRoots(string projectRoot)
+    {
+        var roots = new Dictionary<string, LocalPackageSourceRoot>(StringComparer.OrdinalIgnoreCase);
+        string packagesDirectory = Path.Combine(projectRoot, "Packages");
+        string manifestPath = Path.Combine(packagesDirectory, "manifest.json");
+
+        if (File.Exists(manifestPath))
+        {
+            try
+            {
+                using JsonDocument manifest = JsonDocument.Parse(File.ReadAllText(manifestPath));
+                if (manifest.RootElement.TryGetProperty("dependencies", out JsonElement dependencies) &&
+                    dependencies.ValueKind == JsonValueKind.Object)
+                {
+                    foreach (JsonProperty dependency in dependencies.EnumerateObject())
+                    {
+                        if (dependency.Value.ValueKind != JsonValueKind.String)
+                            continue;
+
+                        string? root = ResolveLocalPackageDependencyRoot(
+                            projectRoot,
+                            packagesDirectory,
+                            dependency.Value.GetString());
+                        if (!string.IsNullOrWhiteSpace(root) && Directory.Exists(root))
+                            AddLocalPackageSourceRoot(roots, root, dependency.Name);
+                    }
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        if (Directory.Exists(packagesDirectory))
+        {
+            try
+            {
+                foreach (string directory in Directory.EnumerateDirectories(packagesDirectory, "*", SearchOption.TopDirectoryOnly))
+                {
+                    string name = Path.GetFileName(directory);
+                    if (string.Equals(name, "PackageCache", StringComparison.OrdinalIgnoreCase))
+                        continue;
+                    if (File.Exists(Path.Combine(directory, "package.json")))
+                        AddLocalPackageSourceRoot(roots, directory, ReadPackageName(directory) ?? name);
+                }
+            }
+            catch
+            {
+            }
+        }
+
+        return roots.Values
+            .OrderBy(root => root.Root, StringComparer.OrdinalIgnoreCase)
+            .ToArray();
+    }
+
+    static void AddLocalPackageSourceRoot(Dictionary<string, LocalPackageSourceRoot> roots, string root, string fallbackPackageName)
+    {
+        try
+        {
+            string fullRoot = Path.GetFullPath(root);
+            string packageName = ReadPackageName(fullRoot) ?? fallbackPackageName;
+            if (!string.IsNullOrWhiteSpace(packageName))
+            {
+                roots[fullRoot] = new LocalPackageSourceRoot
+                {
+                    Root = fullRoot,
+                    PackageName = packageName
+                };
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    static string? ReadPackageName(string packageRoot)
+    {
+        string packageJsonPath = Path.Combine(packageRoot, "package.json");
+        if (!File.Exists(packageJsonPath))
+            return null;
+
+        try
+        {
+            using JsonDocument document = JsonDocument.Parse(File.ReadAllText(packageJsonPath));
+            if (document.RootElement.TryGetProperty("name", out JsonElement nameElement) &&
+                nameElement.ValueKind == JsonValueKind.String)
+            {
+                string? name = nameElement.GetString();
+                return string.IsNullOrWhiteSpace(name) ? null : name.Trim();
+            }
+        }
+        catch
+        {
+        }
+
+        return null;
+    }
+
+    static string? ToPackageAssetPath(LocalPackageSourceRoot root, string file)
+    {
+        try
+        {
+            string relative = Path.GetRelativePath(root.Root, file).Replace('\\', '/');
+            if (relative.StartsWith("../", StringComparison.Ordinal) ||
+                Path.IsPathRooted(relative))
+                return null;
+
+            return $"Packages/{root.PackageName}/{relative}";
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string? ResolveLocalPackageDependencyRoot(string projectRoot, string packagesDirectory, string? dependency)
+    {
+        if (string.IsNullOrWhiteSpace(dependency) ||
+            !dependency.StartsWith("file:", StringComparison.OrdinalIgnoreCase))
+            return null;
+
+        string spec = dependency["file:".Length..].Trim();
+        if (string.IsNullOrWhiteSpace(spec))
+            return null;
+
+        if (Uri.TryCreate(spec, UriKind.Absolute, out Uri? uri) && uri.IsFile)
+            return uri.LocalPath;
+
+        spec = Uri.UnescapeDataString(spec).Replace('/', Path.DirectorySeparatorChar);
+        if (Path.IsPathRooted(spec))
+            return spec;
+
+        string projectRelative = Path.GetFullPath(Path.Combine(projectRoot, spec));
+        if (Directory.Exists(projectRelative))
+            return projectRelative;
+
+        return Path.GetFullPath(Path.Combine(packagesDirectory, spec));
+    }
+
+    static IEnumerable<string> EnumerateCompileAffectingSourceFiles(string root)
+    {
+        if (!Directory.Exists(root))
+            yield break;
+
+        var pending = new Stack<string>();
+        pending.Push(root);
+        while (pending.Count > 0)
+        {
+            string directory = pending.Pop();
+            string[] files;
+            try
+            {
+                files = Directory.GetFiles(directory);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (string file in files)
+            {
+                string extension = Path.GetExtension(file);
+                if (string.Equals(extension, ".cs", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(extension, ".asmdef", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(extension, ".asmref", StringComparison.OrdinalIgnoreCase) ||
+                    string.Equals(extension, ".rsp", StringComparison.OrdinalIgnoreCase))
+                {
+                    yield return file;
+                }
+            }
+
+            string[] childDirectories;
+            try
+            {
+                childDirectories = Directory.GetDirectories(directory);
+            }
+            catch
+            {
+                continue;
+            }
+
+            foreach (string child in childDirectories)
+            {
+                if (ShouldSkipLocalPackageProbeDirectory(child))
+                    continue;
+                pending.Push(child);
+            }
+        }
+    }
+
+    static bool ShouldSkipLocalPackageProbeDirectory(string directory)
+    {
+        string name = Path.GetFileName(directory);
+        return string.IsNullOrWhiteSpace(name) ||
+            name.StartsWith(".", StringComparison.Ordinal) ||
+            name.EndsWith("~", StringComparison.Ordinal) ||
+            string.Equals(name, "Library", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, "Temp", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, "Obj", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, "obj", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, "bin", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, "node_modules", StringComparison.OrdinalIgnoreCase) ||
+            string.Equals(name, "PackageCache", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static string NormalizeUnityChangedPath(string projectRoot, string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return string.Empty;
+
+        string normalized = path.Replace('\\', '/').Trim();
+        if (normalized.StartsWith("unity://path/", StringComparison.OrdinalIgnoreCase))
+            normalized = normalized["unity://path/".Length..];
+        if (normalized.StartsWith("file://", StringComparison.OrdinalIgnoreCase) &&
+            Uri.TryCreate(normalized, UriKind.Absolute, out var uri))
+        {
+            normalized = uri.LocalPath.Replace('\\', '/');
+        }
+
+        if (Path.IsPathRooted(normalized))
+        {
+            try
+            {
+                string fullPath = Path.GetFullPath(normalized).Replace('\\', '/');
+                string rootedProject = Path.GetFullPath(projectRoot).Replace('\\', '/').TrimEnd('/');
+                if (fullPath.StartsWith(rootedProject + "/", StringComparison.OrdinalIgnoreCase))
+                    return fullPath[(rootedProject.Length + 1)..];
+
+                return fullPath;
+            }
+            catch
+            {
+                return normalized;
+            }
+        }
+
+        return normalized.TrimStart('/', '.');
+    }
+
+    static bool IsCompileAffectingPath(string path)
+    {
+        if (string.IsNullOrWhiteSpace(path))
+            return false;
+
+        string normalized = path.Replace('\\', '/').Trim().ToLowerInvariant();
+        return normalized.EndsWith(".cs", StringComparison.Ordinal) ||
+            normalized.EndsWith(".asmdef", StringComparison.Ordinal) ||
+            normalized.EndsWith(".asmref", StringComparison.Ordinal) ||
+            normalized.EndsWith(".rsp", StringComparison.Ordinal) ||
+            normalized == "packages/manifest.json" ||
+            normalized == "packages/packages-lock.json" ||
+            normalized.EndsWith("/package.json", StringComparison.Ordinal);
     }
 
     async Task<JsonElement> CreatePlayModeEnterReadyPayloadAsync(JsonElement argumentsElement, CancellationToken cancellationToken)
@@ -3668,6 +4371,260 @@ sealed class UnityMcpLensHost
         }
     }
 
+    async Task<JsonElement> CreateSelectPackThroughMainMenuPayloadAsync(JsonElement argumentsElement, CancellationToken cancellationToken)
+    {
+        DateTime startedUtc = DateTime.UtcNow;
+        int timeoutMs = Math.Clamp(ExtractInt(argumentsElement, 60000, "timeoutMs", "TimeoutMs"), 1000, 120000);
+        string packId = ExtractString(argumentsElement, "packId", "PackId") ?? "garden";
+        string mainMenuScenePath = ExtractString(argumentsElement, "mainMenuScenePath", "MainMenuScenePath", "scenePath", "ScenePath") ?? "Assets/Scenes/MainMenu.unity";
+        string buttonName = ExtractString(argumentsElement, "buttonName", "ButtonName") ?? $"PackButton_{packId}";
+        string buttonSearchMethod = ExtractString(argumentsElement, "buttonSearchMethod", "ButtonSearchMethod", "searchMethod", "SearchMethod") ?? "by_name";
+        string? explicitExpectedRuntimePackName = ExtractString(argumentsElement, "expectedRuntimePackName", "ExpectedRuntimePackName");
+        string expectedRuntimePackName = explicitExpectedRuntimePackName ?? ToDisplayPackName(packId);
+        int stepsAfterClick = Math.Max(0, ExtractInt(argumentsElement, 10, "stepsAfterClick", "StepsAfterClick"));
+        bool exitAfter = ExtractBool(argumentsElement, true, "exitAfter", "ExitAfter");
+        bool captureConsoleDelta = ExtractBool(argumentsElement, true, "captureConsoleDelta", "CaptureConsoleDelta");
+        bool failOnNewConsoleErrors = ExtractBool(argumentsElement, true, "failOnNewConsoleErrors", "FailOnNewConsoleErrors");
+
+        JsonElement entry = default;
+        JsonElement layout = default;
+        JsonElement invoke = default;
+        JsonElement step = default;
+        JsonElement verify = default;
+        JsonElement exit = default;
+        bool enteredPlayMode = false;
+        bool paused = false;
+        bool buttonFound = false;
+        bool buttonInvoked = false;
+        bool passed = false;
+        bool timedOut = false;
+        string? activeRuntimePackName = null;
+        string? failureCode = null;
+        string? failureMessage = null;
+
+        int RemainingMs() => Math.Max(1000, timeoutMs - (int)Math.Round((DateTime.UtcNow - startedUtc).TotalMilliseconds));
+        TimeSpan RemainingTimeout(int capMs) => TimeSpan.FromMilliseconds(Math.Max(1000, Math.Min(capMs, RemainingMs())));
+
+        try
+        {
+            int entryTimeoutMs = Math.Min(timeoutMs, 60000);
+            entry = await CreatePlayModeStepVerifierPayloadAsync(JsonSerializer.SerializeToElement(new
+            {
+                scenePath = mainMenuScenePath,
+                steps = 0,
+                warmupSteps = 0,
+                exitAfter = false,
+                restorePreviousState = false,
+                captureConsoleDelta = false,
+                failOnNewConsoleErrors = false,
+                timeoutMs = entryTimeoutMs
+            }, m_JsonOptions), cancellationToken).ConfigureAwait(false);
+
+            enteredPlayMode = GetNestedJsonBool(entry, false, "data", "enteredPlayMode");
+            paused = GetNestedJsonBool(entry, false, "data", "verifier", "data", "paused");
+            timedOut = timedOut || GetNestedJsonBool(entry, false, "data", "timedOut");
+            if (IsToolLevelError(entry))
+            {
+                failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_ENTER_FAILED";
+                failureMessage = "Main Menu pack selection could not enter paused Play Mode.";
+            }
+
+            if (failureCode == null)
+            {
+                layout = await CallBridgeToolResultAsync(
+                    "Unity.UI.QueryRuntimeLayout",
+                    new
+                    {
+                        target = buttonName,
+                        searchMethod = buttonSearchMethod,
+                        includeChildren = true,
+                        includeInactive = false,
+                        elementTypes = new[] { "button" },
+                        maxElements = 5,
+                        includeScreenBounds = true
+                    },
+                    cancellationToken,
+                    RemainingTimeout(10000)).ConfigureAwait(false);
+
+                bool layoutSuccess = GetJsonBool(layout, false, "success") && !IsToolLevelError(layout);
+                int? elementCount = GetNestedJsonNullableInt(layout, "data", "totalElementCount") ??
+                    GetNestedJsonNullableInt(layout, "data", "returnedElementCount");
+                buttonFound = layoutSuccess && elementCount.GetValueOrDefault(1) > 0;
+                if (!buttonFound)
+                {
+                    failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_BUTTON_NOT_FOUND";
+                    failureMessage = $"Main Menu pack button '{buttonName}' was not found.";
+                }
+            }
+
+            if (failureCode == null)
+            {
+                invoke = await CallBridgeToolResultAsync(
+                    "Unity.UI.InvokeControl",
+                    new
+                    {
+                        target = buttonName,
+                        searchMethod = buttonSearchMethod,
+                        includeInactive = false,
+                        action = "click",
+                        waitFrames = 1,
+                        captureConsoleDelta
+                    },
+                    cancellationToken,
+                    RemainingTimeout(10000)).ConfigureAwait(false);
+
+                buttonInvoked = GetJsonBool(invoke, false, "success") && !IsToolLevelError(invoke);
+                if (!buttonInvoked)
+                {
+                    failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_INVOKE_FAILED";
+                    failureMessage = $"Main Menu pack button '{buttonName}' could not be invoked.";
+                }
+            }
+
+            if (failureCode == null)
+            {
+                step = await CallBridgeToolResultAsync(
+                    "Unity.PlayMode.StepVerifier",
+                    new
+                    {
+                        steps = stepsAfterClick,
+                        warmupSteps = 0,
+                        exitAfter = false,
+                        restorePreviousState = false,
+                        captureConsoleDelta,
+                        failOnNewConsoleErrors,
+                        allowRealtimeRun = false,
+                        timeoutMs = RemainingMs()
+                    },
+                    cancellationToken,
+                    RemainingTimeout(60000)).ConfigureAwait(false);
+
+                paused = paused || GetNestedJsonBool(step, false, "data", "paused");
+                timedOut = timedOut || GetNestedJsonBool(step, false, "data", "timedOut");
+                if (IsToolLevelError(step))
+                {
+                    failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_STEP_FAILED";
+                    failureMessage = "Main Menu pack selection did not complete bounded paused steps after invoking the button.";
+                }
+            }
+
+            if (failureCode == null)
+            {
+                verify = await CallBridgeToolResultAsync(
+                    "Unity.Workflow.VerifyRuntimePackSelection",
+                    new
+                    {
+                        selectedPackId = packId,
+                        requirePlayMode = true,
+                        selectPack = false,
+                        timeoutMs = RemainingMs()
+                    },
+                    cancellationToken,
+                    RemainingTimeout(30000)).ConfigureAwait(false);
+
+                activeRuntimePackName = GetNestedJsonString(verify, "data", "activeRuntimePackName");
+                bool nativePassed = GetNestedJsonBool(verify, false, "data", "passed") && !IsToolLevelError(verify);
+                bool packMatches = MatchesExpectedPackName(activeRuntimePackName, packId, expectedRuntimePackName, explicitExpectedRuntimePackName != null);
+                passed = nativePassed && packMatches;
+                if (!passed)
+                {
+                    failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_VERIFY_FAILED";
+                    failureMessage = $"Main Menu pack selection did not verify expected runtime pack '{expectedRuntimePackName}'.";
+                }
+            }
+        }
+        catch (Exception ex)
+        {
+            failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_FAILED";
+            failureMessage = $"Main Menu pack selection workflow failed: {ex.Message}";
+        }
+
+        if (exitAfter && enteredPlayMode)
+        {
+            try
+            {
+                exit = await CallBridgeToolResultAsync(
+                    "Unity.PlayMode.StepVerifier",
+                    new
+                    {
+                        steps = 0,
+                        warmupSteps = 0,
+                        exitAfter = true,
+                        restorePreviousState = false,
+                        captureConsoleDelta = false,
+                        failOnNewConsoleErrors = false,
+                        timeoutMs = RemainingMs()
+                    },
+                    cancellationToken,
+                    RemainingTimeout(30000)).ConfigureAwait(false);
+
+                if (failureCode == null && IsToolLevelError(exit))
+                {
+                    failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_EXIT_FAILED";
+                    failureMessage = "Main Menu pack selection verified the pack but failed to exit Play Mode cleanly.";
+                }
+            }
+            catch (Exception ex)
+            {
+                if (failureCode == null)
+                {
+                    failureCode = "UNITY_MCP_SELECT_PACK_MAIN_MENU_EXIT_FAILED";
+                    failureMessage = $"Main Menu pack selection verified the pack but failed to exit Play Mode: {ex.Message}";
+                }
+            }
+        }
+
+        HostHealthEvaluation afterHealth = BuildCurrentHostHealthEvaluation();
+        bool editorResponsiveAfter = afterHealth.Contract.State is "unity_alive_fresh" or "editor_busy_healthy" or "bridge_alive_no_editor_heartbeat";
+        object? consoleDelta = TryGetNestedProperty(step, out var stepConsoleDelta, "data", "consoleDelta")
+            ? stepConsoleDelta.Clone()
+            : TryGetNestedProperty(invoke, out var invokeConsoleDelta, "data", "consoleDelta")
+                ? invokeConsoleDelta.Clone()
+                : null;
+        object? JsonOrNull(JsonElement element) => element.ValueKind == JsonValueKind.Undefined ? null : element.Clone();
+        object data = new
+        {
+            packId,
+            mainMenuScenePath,
+            buttonName,
+            buttonSearchMethod,
+            expectedRuntimePackName,
+            enteredPlayMode,
+            paused,
+            buttonFound,
+            buttonInvoked,
+            stepsAfterClick,
+            activeRuntimePackName,
+            passed = passed && failureCode == null,
+            timedOut,
+            editorResponsiveAfter,
+            timeoutMs,
+            elapsedMs = Math.Round((DateTime.UtcNow - startedUtc).TotalMilliseconds, 3),
+            exitAfter,
+            captureConsoleDelta,
+            failOnNewConsoleErrors,
+            consoleDelta,
+            entry = JsonOrNull(entry),
+            layout = JsonOrNull(layout),
+            invoke = JsonOrNull(invoke),
+            step = JsonOrNull(step),
+            verify = JsonOrNull(verify),
+            exit = JsonOrNull(exit),
+            afterHealth = CreateHealthEvaluationDiagnostics(afterHealth),
+            host = CreateHostDiagnostics()
+        };
+
+        if (failureCode != null)
+            return CreateErrorPayload(failureMessage ?? "Main Menu pack selection failed.", failureCode, data);
+
+        return JsonSerializer.SerializeToElement(new
+        {
+            success = true,
+            message = "FallingSands pack selected through the Main Menu.",
+            data
+        }, m_JsonOptions);
+    }
+
     async Task<object> EnsureRuntimePackActiveForEnterReadyAsync(bool includeScenePack, CancellationToken cancellationToken)
     {
         string[] before = m_ActiveToolPacks.ToArray();
@@ -3765,6 +4722,145 @@ sealed class UnityMcpLensHost
                 path = string.IsNullOrWhiteSpace(directory) ? string.Empty : directory
             },
             cancellationToken).ConfigureAwait(false);
+    }
+
+    async Task<RunCommandSafetyBypassResult> EvaluateRunCommandStablePlayModeBypassAsync(CancellationToken cancellationToken)
+    {
+        HostHealthEvaluation health = BuildCurrentHostHealthEvaluation();
+        m_LastBridgeDiscoverySnapshot = health.Snapshot;
+        var editorHealth = health.EditorHealth?.HealthFile;
+        if (!HasProvenFreshBridgeEditorPair(health) || editorHealth == null)
+        {
+            return new RunCommandSafetyBypassResult
+            {
+                Allowed = false,
+                FailureKind = "fresh_bridge_editor_pair_not_proven",
+                Reason = "Health did not prove a fresh selected bridge/editor-health pair.",
+                Health = health
+            };
+        }
+
+        bool transitionOnly = editorHealth.IsPlayingOrWillChangePlaymode && !editorHealth.IsPlaying;
+        if (!editorHealth.IsPlaying ||
+            transitionOnly ||
+            editorHealth.IsCompiling ||
+            editorHealth.IsImporting ||
+            editorHealth.IsUpdating ||
+            editorHealth.IsBuildingPlayer)
+        {
+            return new RunCommandSafetyBypassResult
+            {
+                Allowed = false,
+                FailureKind = "editor_not_stable_play_mode",
+                Reason = "Editor health is not stable Play Mode.",
+                Health = health
+            };
+        }
+
+        object consoleBefore = await TryReadConsoleErrorSummaryAsync(cancellationToken).ConfigureAwait(false);
+        int? consoleCursor = ExtractConsoleCursor(consoleBefore);
+        if (!consoleCursor.HasValue)
+        {
+            return new RunCommandSafetyBypassResult
+            {
+                Allowed = false,
+                FailureKind = "console_cursor_missing",
+                Reason = "Unity.ReadConsole did not return a cursor for the Play Mode safety check.",
+                Health = health,
+                ConsoleBefore = consoleBefore
+            };
+        }
+
+        JsonElement runtimeState;
+        try
+        {
+            runtimeState = await CallBridgeToolResultAsync(
+                "Unity.ManageEditor",
+                new { action = "GetCompactState" },
+                cancellationToken,
+                TimeSpan.FromSeconds(5)).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            return new RunCommandSafetyBypassResult
+            {
+                Allowed = false,
+                FailureKind = "runtime_probe_failed",
+                Reason = $"Runtime state probe failed: {ex.Message}",
+                Health = health,
+                ConsoleBefore = consoleBefore
+            };
+        }
+
+        bool stateSuccess = GetJsonBool(runtimeState, false, "success");
+        bool stateIsPlaying = GetNestedJsonBool(runtimeState, false, "data", "isPlaying");
+        bool stateIsPaused = GetNestedJsonBool(runtimeState, false, "data", "isPaused");
+        bool stateIsCompiling = GetNestedJsonBool(runtimeState, false, "data", "isCompiling");
+        bool stateIsUpdating = GetNestedJsonBool(runtimeState, false, "data", "isUpdating");
+        bool stateIsBuilding = GetNestedJsonBool(runtimeState, false, "data", "isBuildingPlayer");
+        bool stateTransitionOnly = GetNestedJsonBool(runtimeState, false, "data", "isPlayingOrWillChangePlaymode") && !stateIsPlaying;
+        bool runtimeProbeAvailable = GetNestedJsonBool(runtimeState, false, "data", "runtimeProbe", "isAvailable");
+        bool runtimeAdvanced = GetNestedJsonBool(runtimeState, false, "data", "runtimeAdvanced") ||
+            GetNestedJsonBool(runtimeState, false, "data", "runtimeProbe", "hasAdvancedFrames");
+        bool pausedReady = stateIsPlaying && stateIsPaused && runtimeProbeAvailable;
+        if (!stateSuccess ||
+            !stateIsPlaying ||
+            stateTransitionOnly ||
+            stateIsCompiling ||
+            stateIsUpdating ||
+            stateIsBuilding ||
+            (!runtimeAdvanced && !pausedReady))
+        {
+            return new RunCommandSafetyBypassResult
+            {
+                Allowed = false,
+                FailureKind = "runtime_not_ready_for_runcommand",
+                Reason = "Runtime probe did not prove advancing or paused-ready Play Mode.",
+                Health = health,
+                RuntimeState = runtimeState.Clone(),
+                ConsoleBefore = consoleBefore,
+                RuntimeProbeAvailable = runtimeProbeAvailable,
+                RuntimeAdvanced = runtimeAdvanced,
+                PausedReady = pausedReady
+            };
+        }
+
+        object consoleAfter = await TryReadConsoleErrorSummaryAsync(cancellationToken, consoleCursor).ConfigureAwait(false);
+        int newConsoleErrorCount = ExtractConsoleNewErrorCount(consoleAfter) ?? ExtractConsoleErrorCount(consoleAfter) ?? 0;
+        if (newConsoleErrorCount > 0)
+        {
+            return new RunCommandSafetyBypassResult
+            {
+                Allowed = false,
+                FailureKind = "new_console_errors_detected",
+                Reason = "Console changed with new error/exception/assert entries during the Play Mode safety check.",
+                Health = health,
+                RuntimeState = runtimeState.Clone(),
+                ConsoleBefore = consoleBefore,
+                ConsoleAfter = consoleAfter,
+                RuntimeProbeAvailable = runtimeProbeAvailable,
+                RuntimeAdvanced = runtimeAdvanced,
+                PausedReady = pausedReady,
+                NewConsoleErrorCount = newConsoleErrorCount
+            };
+        }
+
+        return new RunCommandSafetyBypassResult
+        {
+            Allowed = true,
+            FailureKind = string.Empty,
+            Reason = pausedReady
+                ? "Fresh bridge/editor pair is in paused-ready Play Mode with no new console errors."
+                : "Fresh bridge/editor pair is in advancing Play Mode with no new console errors.",
+            Health = health,
+            RuntimeState = runtimeState.Clone(),
+            ConsoleBefore = consoleBefore,
+            ConsoleAfter = consoleAfter,
+            RuntimeProbeAvailable = runtimeProbeAvailable,
+            RuntimeAdvanced = runtimeAdvanced,
+            PausedReady = pausedReady,
+            NewConsoleErrorCount = newConsoleErrorCount
+        };
     }
 
     async Task<JsonElement> CallRunCommandWithWatchdogAsync(
@@ -4038,19 +5134,36 @@ sealed class UnityMcpLensHost
     {
         try
         {
-            return await CallBridgeToolResultAsync(
-                "Unity.ReadConsole",
-                new
+            return await ReadConsoleErrorSummaryOnceAsync(cancellationToken, cursor).ConfigureAwait(false);
+        }
+        catch (Exception ex) when (IsBridgeTransportFailure(ex))
+        {
+            BridgeRecoveryState recoveryState = new()
+            {
+                RetrySafe = true,
+                RetryAttempted = true
+            };
+            try
+            {
+                Console.Error.WriteLine($"[unity-mcp-lens] Unity.ReadConsole transport failed, reconnecting and retrying once: {ex.Message}");
+                await RecoverBridgeAfterTransportFailureAsync(ex, "Unity.ReadConsole", recoveryState, cancellationToken).ConfigureAwait(false);
+                object retry = await ReadConsoleErrorSummaryOnceAsync(cancellationToken, cursor).ConfigureAwait(false);
+                recoveryState.RetrySucceeded = true;
+                m_LastRecoveryState = recoveryState;
+                return retry;
+            }
+            catch (Exception retryEx)
+            {
+                return new
                 {
-                    action = "Get",
-                    types = new[] { "Error", "Warning", "Exception", "Assert" },
-                    count = 100,
-                    cursor,
-                    format = "Summary",
-                    excludeMcpNoise = true,
-                    includeStacktrace = false
-                },
-                cancellationToken).ConfigureAwait(false);
+                    success = false,
+                    error = retryEx.Message,
+                    exceptionType = retryEx.GetType().Name,
+                    retryAttempted = true,
+                    initialExceptionType = ex.GetType().Name,
+                    initialError = ex.Message
+                };
+            }
         }
         catch (Exception ex)
         {
@@ -4061,6 +5174,23 @@ sealed class UnityMcpLensHost
                 exceptionType = ex.GetType().Name
             };
         }
+    }
+
+    async Task<JsonElement> ReadConsoleErrorSummaryOnceAsync(CancellationToken cancellationToken, int? cursor)
+    {
+        return await CallBridgeToolResultAsync(
+            "Unity.ReadConsole",
+            new
+            {
+                action = "Get",
+                types = new[] { "Error", "Warning", "Exception", "Assert" },
+                count = 100,
+                cursor,
+                format = "Summary",
+                excludeMcpNoise = true,
+                includeStacktrace = false
+            },
+            cancellationToken).ConfigureAwait(false);
     }
 
     async Task<HostSyncReadyResult> WaitForScriptSyncReadyFromHostAsync(
@@ -4596,9 +5726,35 @@ sealed class UnityMcpLensHost
             .ToArray();
     }
 
+    static string[] GetJsonStringArray(JsonElement element, params string[] names)
+    {
+        if (!TryGetPropertyIgnoreCase(element, out var value, names) || value.ValueKind != JsonValueKind.Array)
+            return [];
+
+        return value.EnumerateArray()
+            .Where(item => item.ValueKind == JsonValueKind.String)
+            .Select(item => item.GetString())
+            .Where(item => !string.IsNullOrWhiteSpace(item))
+            .Cast<string>()
+            .ToArray();
+    }
+
     static bool GetJsonBool(JsonElement element, bool fallback, params string[] names)
     {
         if (!TryGetPropertyIgnoreCase(element, out var value, names))
+            return fallback;
+
+        return value.ValueKind switch
+        {
+            JsonValueKind.True => true,
+            JsonValueKind.False => false,
+            _ => fallback
+        };
+    }
+
+    static bool GetNestedJsonBool(JsonElement element, bool fallback, params string[] path)
+    {
+        if (!TryGetNestedProperty(element, out var value, path))
             return fallback;
 
         return value.ValueKind switch
@@ -4627,6 +5783,15 @@ sealed class UnityMcpLensHost
             : null;
     }
 
+    static int? GetNestedJsonNullableInt(JsonElement element, params string[] path)
+    {
+        return TryGetNestedProperty(element, out var value, path) &&
+            value.ValueKind == JsonValueKind.Number &&
+            value.TryGetInt32(out int result)
+            ? result
+            : null;
+    }
+
     static double GetJsonDouble(JsonElement element, double fallback, params string[] names)
     {
         return TryGetPropertyIgnoreCase(element, out var value, names) &&
@@ -4641,6 +5806,38 @@ sealed class UnityMcpLensHost
         return TryGetPropertyIgnoreCase(element, out var value, names) && value.ValueKind == JsonValueKind.String
             ? value.GetString()
             : null;
+    }
+
+    static string? GetNestedJsonString(JsonElement element, params string[] path)
+    {
+        return TryGetNestedProperty(element, out var value, path) && value.ValueKind == JsonValueKind.String
+            ? value.GetString()
+            : null;
+    }
+
+    static string ToDisplayPackName(string packId)
+    {
+        string[] parts = (packId ?? string.Empty)
+            .Split(['_', '-', ' '], StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+        if (parts.Length == 0)
+            return string.Empty;
+
+        return string.Join(" ", parts.Select(part =>
+            part.Length == 0
+                ? part
+                : char.ToUpperInvariant(part[0]) + (part.Length == 1 ? string.Empty : part[1..])));
+    }
+
+    static bool MatchesExpectedPackName(string? activeRuntimePackName, string packId, string expectedRuntimePackName, bool explicitExpectedRuntimePackName)
+    {
+        if (string.IsNullOrWhiteSpace(activeRuntimePackName))
+            return false;
+
+        if (string.Equals(activeRuntimePackName, expectedRuntimePackName, StringComparison.OrdinalIgnoreCase))
+            return true;
+
+        return !explicitExpectedRuntimePackName &&
+            string.Equals(activeRuntimePackName, packId, StringComparison.OrdinalIgnoreCase);
     }
 
     static int? ExtractConsoleErrorCount(object? consoleSummary)
@@ -4936,6 +6133,8 @@ sealed class UnityMcpLensHost
             editorPidAlive = result.EditorPidAlive,
             fresh = result.IsFresh,
             basicHealth = result.BasicHealth,
+            editorHealthMatchQuality = result.EditorHealthMatchQuality,
+            editorHealthBridgePidMatch = result.EditorHealthBridgePidMatch,
             editorHealth = result.EditorHealth == null ? null : CreateEditorHealthDiagnostics(result.EditorHealth),
             supportsToolSyncLens = result.StatusFile.SupportsToolSyncLens,
             bridgeSessionId = result.StatusFile.BridgeSessionId,
@@ -4958,6 +6157,8 @@ sealed class UnityMcpLensHost
             editorPidAlive = candidate.EditorPidAlive,
             fresh = candidate.IsFresh,
             basicHealth = candidate.BasicHealth,
+            editorHealthMatchQuality = candidate.EditorHealthMatchQuality,
+            editorHealthBridgePidMatch = candidate.EditorHealthBridgePidMatch,
             ignoredMalformed = candidate.IsIgnoredMalformed,
             malformedIgnoreReason = candidate.MalformedIgnoreReason,
             projectHashMatch = candidate.ProjectHashMatch,
@@ -4987,6 +6188,12 @@ sealed class UnityMcpLensHost
             editorPidAlive = candidate.EditorPidAlive,
             editorProcessStartUtc = candidate.EditorProcessStartUtc == DateTime.MinValue ? null : candidate.EditorProcessStartUtc.ToString("O"),
             pidStartMatches = candidate.PidStartMatches,
+            editorProcessName = candidate.EditorProcessName,
+            editorProcessPath = candidate.EditorProcessPath,
+            editorProcessLooksLikeUnity = candidate.EditorProcessLooksLikeUnity,
+            commandLineAvailable = candidate.CommandLineAvailable,
+            projectCommandLineMatch = candidate.ProjectCommandLineMatch,
+            projectCommandLineEvidence = candidate.ProjectCommandLineEvidence,
             fresh = candidate.IsFresh,
             ignoredMalformed = candidate.IsIgnoredMalformed,
             malformedIgnoreReason = candidate.MalformedIgnoreReason,
@@ -5091,7 +6298,7 @@ sealed class UnityMcpLensHost
     {
         string? rawMode = Environment.GetEnvironmentVariable(ToolSurfaceModeEnvVar);
         if (string.IsNullOrWhiteSpace(rawMode))
-            return DynamicPacksToolSurfaceMode;
+            return StaticAllToolSurfaceMode;
 
         string mode = rawMode.Trim();
         if (string.Equals(mode, DynamicPacksToolSurfaceMode, StringComparison.OrdinalIgnoreCase))
@@ -5099,8 +6306,8 @@ sealed class UnityMcpLensHost
         if (string.Equals(mode, StaticAllToolSurfaceMode, StringComparison.OrdinalIgnoreCase))
             return StaticAllToolSurfaceMode;
 
-        Console.Error.WriteLine($"[unity-mcp-lens] Unknown {ToolSurfaceModeEnvVar} value '{rawMode}'. Falling back to {DynamicPacksToolSurfaceMode}.");
-        return DynamicPacksToolSurfaceMode;
+        Console.Error.WriteLine($"[unity-mcp-lens] Unknown {ToolSurfaceModeEnvVar} value '{rawMode}'. Falling back to {StaticAllToolSurfaceMode}.");
+        return StaticAllToolSurfaceMode;
     }
 
     static string ResolveHostVersion()

--- a/UnityMcpLensApp~/src/UnityMcpLens/ReloadSceneModalTool.cs
+++ b/UnityMcpLensApp~/src/UnityMcpLens/ReloadSceneModalTool.cs
@@ -1,0 +1,300 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Text.Json;
+
+namespace UnityMcpLens;
+
+static class ReloadSceneModalTool
+{
+    public const string ToolName = "Unity_Editor_ReloadSceneModal";
+
+    public static bool MatchesToolName(string toolName)
+    {
+        return string.Equals(
+            CanonicalizeToolName(toolName),
+            ToolName,
+            StringComparison.OrdinalIgnoreCase);
+    }
+
+    public static BridgeToolDescriptor BuildDescriptor(JsonSerializerOptions jsonOptions)
+    {
+        var inputSchema = JsonSerializer.SerializeToElement(new
+        {
+            type = "object",
+            properties = new Dictionary<string, object?>
+            {
+                ["timeoutMs"] = new
+                {
+                    type = "integer",
+                    description = "Maximum time to wait for a reload-scene modal before returning.",
+                    @default = 0,
+                    minimum = 0,
+                    maximum = 30000
+                },
+                ["pollIntervalMs"] = new
+                {
+                    type = "integer",
+                    description = "Polling interval while waiting for the modal.",
+                    @default = 250,
+                    minimum = 50,
+                    maximum = 5000
+                }
+            }
+        }, jsonOptions);
+
+        return new BridgeToolDescriptor
+        {
+            Name = ToolName,
+            Title = "Reload Scene Modal Detector",
+            Description = "Detects Unity reload-scene consent dialogs from the Lens host and reports candidate process/window/text/button diagnostics. V1 is detect-only and never clicks.",
+            Groups = ["assistant", "core", "editor", "diagnostics"],
+            Packs = ["foundation"],
+            ReadOnlyHint = true,
+            InputSchema = inputSchema,
+            OutputSchema = JsonSerializer.SerializeToElement(new { type = "object" }, jsonOptions),
+            Annotations = JsonSerializer.SerializeToElement(new { readOnlyHint = true }, jsonOptions)
+        };
+    }
+
+    public static JsonElement Execute(JsonElement arguments, JsonSerializerOptions jsonOptions)
+    {
+        int timeoutMs = Math.Clamp(GetInt(arguments, 0, "timeoutMs", "TimeoutMs"), 0, 30000);
+        int pollIntervalMs = Math.Clamp(GetInt(arguments, 250, "pollIntervalMs", "PollIntervalMs"), 50, 5000);
+        var stopwatch = Stopwatch.StartNew();
+
+        if (!OperatingSystem.IsWindows())
+        {
+            return BuildPayload(jsonOptions, false, "Reload scene modal detection is only available on Windows.", [], timeoutMs, pollIntervalMs, (int)stopwatch.ElapsedMilliseconds);
+        }
+
+        List<ReloadSceneModalSnapshot> snapshots;
+        do
+        {
+            snapshots = FindReloadSceneDialogs();
+            if (snapshots.Count > 0 || stopwatch.ElapsedMilliseconds >= timeoutMs)
+                break;
+
+            Thread.Sleep(Math.Min(pollIntervalMs, Math.Max(1, timeoutMs - (int)stopwatch.ElapsedMilliseconds)));
+        }
+        while (true);
+
+        return BuildPayload(
+            jsonOptions,
+            true,
+            snapshots.Count == 0 ? "No reload-scene modal found." : "Reload-scene modal candidate(s) detected.",
+            snapshots,
+            timeoutMs,
+            pollIntervalMs,
+            (int)stopwatch.ElapsedMilliseconds);
+    }
+
+    static JsonElement BuildPayload(
+        JsonSerializerOptions jsonOptions,
+        bool success,
+        string message,
+        IReadOnlyList<ReloadSceneModalSnapshot> snapshots,
+        int timeoutMs,
+        int pollIntervalMs,
+        int elapsedMs)
+    {
+        return JsonSerializer.SerializeToElement(new
+        {
+            success,
+            message,
+            data = new
+            {
+                found = snapshots.Count > 0,
+                candidateCount = snapshots.Count,
+                timeoutMs,
+                pollIntervalMs,
+                elapsedMs,
+                candidates = snapshots.Select(snapshot => new
+                {
+                    snapshot.Title,
+                    snapshot.ProcessId,
+                    snapshot.ProcessName,
+                    snapshot.IsLikelyUnityProcess,
+                    windowHandle = FormatHandle(snapshot.WindowHandle),
+                    snapshot.ButtonTexts,
+                    childTextPreview = snapshot.ChildTexts.Take(16).ToArray()
+                }).ToArray()
+            }
+        }, jsonOptions);
+    }
+
+    static List<ReloadSceneModalSnapshot> FindReloadSceneDialogs()
+    {
+        var snapshots = new List<ReloadSceneModalSnapshot>();
+        NativeMethods.EnumWindows((windowHandle, _) =>
+        {
+            if (!NativeMethods.IsWindowVisible(windowHandle))
+                return true;
+
+            string title = GetWindowText(windowHandle);
+            if (!LooksLikeReloadSceneTitle(title))
+                return true;
+
+            ReloadSceneModalSnapshot snapshot = BuildSnapshot(windowHandle, title);
+            if (snapshot.IsLikelyUnityProcess && LooksLikeReloadSceneText(snapshot))
+                snapshots.Add(snapshot);
+            return true;
+        }, IntPtr.Zero);
+
+        return snapshots
+            .OrderByDescending(snapshot => snapshot.IsLikelyUnityProcess)
+            .ThenBy(snapshot => snapshot.Title, StringComparer.Ordinal)
+            .ToList();
+    }
+
+    static bool LooksLikeReloadSceneTitle(string title)
+    {
+        return !string.IsNullOrWhiteSpace(title) &&
+            title.Contains("reload", StringComparison.OrdinalIgnoreCase) &&
+            title.Contains("scene", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static bool LooksLikeReloadSceneText(ReloadSceneModalSnapshot snapshot)
+    {
+        string text = string.Join("\n", snapshot.ChildTexts);
+        return text.Contains("reload", StringComparison.OrdinalIgnoreCase) ||
+            text.Contains("scene", StringComparison.OrdinalIgnoreCase);
+    }
+
+    static ReloadSceneModalSnapshot BuildSnapshot(IntPtr windowHandle, string title)
+    {
+        NativeMethods.GetWindowThreadProcessId(windowHandle, out uint processId);
+        string? processName = TryGetProcessName(processId);
+        var childTexts = new List<string>();
+        var buttonTexts = new List<string>();
+
+        NativeMethods.EnumChildWindows(windowHandle, (childHandle, _) =>
+        {
+            string text = NormalizeControlText(GetWindowText(childHandle));
+            if (string.IsNullOrEmpty(text))
+                return true;
+
+            childTexts.Add(text);
+            string className = GetClassName(childHandle);
+            if (className.Contains("Button", StringComparison.OrdinalIgnoreCase))
+                buttonTexts.Add(text);
+
+            return true;
+        }, IntPtr.Zero);
+
+        return new ReloadSceneModalSnapshot(
+            windowHandle,
+            title,
+            processId,
+            processName,
+            processName?.Contains("Unity", StringComparison.OrdinalIgnoreCase) == true,
+            childTexts.Distinct(StringComparer.OrdinalIgnoreCase).ToArray(),
+            buttonTexts.Distinct(StringComparer.OrdinalIgnoreCase).ToArray());
+    }
+
+    static int GetInt(JsonElement arguments, int fallback, params string[] names)
+    {
+        if (arguments.ValueKind != JsonValueKind.Object)
+            return fallback;
+
+        foreach (string name in names)
+        {
+            if (arguments.TryGetProperty(name, out var value) &&
+                value.ValueKind == JsonValueKind.Number &&
+                value.TryGetInt32(out int result))
+            {
+                return result;
+            }
+        }
+
+        foreach (JsonProperty property in arguments.EnumerateObject())
+        {
+            if (names.Any(name => string.Equals(property.Name, name, StringComparison.OrdinalIgnoreCase)) &&
+                property.Value.ValueKind == JsonValueKind.Number &&
+                property.Value.TryGetInt32(out int result))
+            {
+                return result;
+            }
+        }
+
+        return fallback;
+    }
+
+    static string GetWindowText(IntPtr windowHandle)
+    {
+        int length = NativeMethods.GetWindowTextLength(windowHandle);
+        var builder = new StringBuilder(length + 1);
+        NativeMethods.GetWindowText(windowHandle, builder, builder.Capacity);
+        return builder.ToString();
+    }
+
+    static string GetClassName(IntPtr windowHandle)
+    {
+        var builder = new StringBuilder(256);
+        NativeMethods.GetClassName(windowHandle, builder, builder.Capacity);
+        return builder.ToString();
+    }
+
+    static string NormalizeControlText(string text)
+    {
+        return string.Join(" ", (text ?? string.Empty)
+            .Replace("\r", " ")
+            .Replace("\n", " ")
+            .Split(' ', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries));
+    }
+
+    static string? TryGetProcessName(uint processId)
+    {
+        try
+        {
+            using Process process = Process.GetProcessById((int)processId);
+            return process.ProcessName;
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    static string FormatHandle(IntPtr handle) => "0x" + handle.ToInt64().ToString("X");
+
+    static string CanonicalizeToolName(string toolName)
+    {
+        return (toolName ?? string.Empty).Replace('.', '_');
+    }
+
+    sealed record ReloadSceneModalSnapshot(
+        IntPtr WindowHandle,
+        string Title,
+        uint ProcessId,
+        string? ProcessName,
+        bool IsLikelyUnityProcess,
+        string[] ChildTexts,
+        string[] ButtonTexts);
+
+    static class NativeMethods
+    {
+        public delegate bool EnumWindowsProc(IntPtr hWnd, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool EnumWindows(EnumWindowsProc enumProc, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool EnumChildWindows(IntPtr hWndParent, EnumWindowsProc enumProc, IntPtr lParam);
+
+        [DllImport("user32.dll")]
+        public static extern bool IsWindowVisible(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int GetWindowText(IntPtr hWnd, StringBuilder lpString, int nMaxCount);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int GetWindowTextLength(IntPtr hWnd);
+
+        [DllImport("user32.dll", SetLastError = true, CharSet = CharSet.Unicode)]
+        public static extern int GetClassName(IntPtr hWnd, StringBuilder lpClassName, int nMaxCount);
+
+        [DllImport("user32.dll", SetLastError = true)]
+        public static extern uint GetWindowThreadProcessId(IntPtr hWnd, out uint lpdwProcessId);
+    }
+}

--- a/UnityMcpLensApp~/unity-mcp-lens.json
+++ b/UnityMcpLensApp~/unity-mcp-lens.json
@@ -1,6 +1,6 @@
 {
   "name": "unity-mcp-lens",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.153",
   "protocolVersion": "1.0",
   "capabilities": [
     "mcp",

--- a/docs/RoadMap.md
+++ b/docs/RoadMap.md
@@ -10,7 +10,7 @@ when Unity reloads, recompiles, or changes project/package state.
 
 - Standalone package id: `com.becool3000.unity-mcp-lens`.
 - Preferred MCP transport: the owned `unity-mcp-lens` stdio server.
-- Default Codex model-facing tool surface: `static_all` (`foundation+full`); raw host default remains dynamic packs.
+- Default Lens host tool surface: `static_all` (`foundation+full`); `dynamic_packs` remains available through `UNITY_MCP_LENS_TOOL_SURFACE_MODE=dynamic_packs`.
 - Current `foundation` baseline: `18` exported tools.
 - Current `foundation + scene` baseline: `50` exported tools.
 - Current `foundation + ui` baseline: `35` exported tools.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.becool3000.unity-mcp-lens",
   "displayName": "Unity MCP Lens",
-  "version": "0.1.0-alpha.12",
+  "version": "0.1.0-alpha.153",
   "unity": "6000.0",
   "description": "Standalone Unity MCP bridge and tool-surface package focused on low-noise tool sync, narrow model-facing packs, compact outputs, and owned MCP server integration for external agents.",
   "author": {


### PR DESCRIPTION
﻿## Summary
- Harden host reliability around live bridge/editor-health identity selection, unsafe-latch clearing, stable Play Mode RunCommand safety, and read-only console retry.
- Add script assembly reload proof to `Unity.Editor.SyncScripts`, compact StepVerifier evidence behind detail refs, and serialize `Unity.Runtime.InvokeComponentMethod` returned data.
- Make raw host default `static_all` unless `UNITY_MCP_LENS_TOOL_SURFACE_MODE=dynamic_packs` is explicitly set.
- Add reload-scene modal detection, Command Center telemetry scanning, single-step batch helper parsing, and Roach sprite-sheet idempotence for existing names.
- Refresh Lens Codex plugin guidance and docs for the new reliability workflow.

## Dogfood
- BeeSurvivors Roach sprite workflow validated with Lens asset tools: preview/apply import+bind, verify sprite array binding, and no-op apply behavior without custom import/bind RunCommand fallback.
- BeeSurvivors worktree was left clean.

## Validation
- `dotnet build UnityMcpLensApp~\src\UnityMcpLens\UnityMcpLens.csproj -p:SkipLensVersionBump=true`
- `Tools~\Test-McpHostTransportRecovery.ps1`
- `Tools~\Test-McpDynamicToolExposure.ps1`
- `node Tools~\Test-InvokeUnityMcpBatchParsing.js`
- `git diff --check`

## Reviewer Checklist
- [ ] Health selection ignores stale/dead same-project health files when a fresh matching live bridge exists.
- [ ] `Unity.Editor.SyncScripts` reports assembly reload proof and warns when compile observation is missing after source edits.
- [ ] `Unity.Runtime.InvokeComponentMethod` keeps `returnValue` compatibility while exposing compact `returnedData*` fields.
- [ ] Stable Play Mode RunCommand bypass is scoped to fresh bridge/health, idle editor state, and clean console deltas.
- [ ] StepVerifier keeps pass/fail evidence inline while moving bulky snapshots and dirty asset lists behind `detailRef`.
- [ ] `static_all` is now the no-env host default, with explicit `dynamic_packs` still covered by tests.
- [ ] Roach sprite-sheet apply is idempotent when existing sprite geometry/names already match.

## GitNexus
- Full sprint pre-commit check reported CRITICAL risk: 284 changed symbols, 70 affected flows.
- Host/package staged slice reported CRITICAL risk: 444 changed symbols, 70 affected flows, centered on host tool dispatch, bridge/health selection, script sync readiness, RunCommand recovery, StepVerifier, runtime invoke, and sprite binding.
- Plugin/helper staged slice reported LOW risk with no indexed execution-flow hits.
- Post-commit `gitnexus.detect_changes(scope: all)` reported no remaining changes.

## CI / Review State
- GitHub currently reports no configured status checks for this branch.
- No review comments or requested changes were present at PR readiness time.
